### PR TITLE
Multiple Servers Support Pull Request

### DIFF
--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -17,21 +17,6 @@ extension Application {
         self.servers.use(serverProvider)
     }
     
-//    public var server: Server {
-//        guard let makeServer = self.servers.storage.makeServer else {
-//            fatalError("No server configured. Configure with app.servers.use(...)")
-//        }
-//        return makeServer(self)
-//    }
-    
-    public func server<S:Server>(for sec:S.Type) -> S? {
-        self.server(forKey: sec.key) as? S
-    }
-    
-    public func server(forKey key:String) -> Server? {
-        self.servers.storage.servers.first(where: { $0.key == key })?.value
-    }
-    
     public var listenAddresses:[Multiaddr] {
         self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
             partialResult.append(server.listeningAddress)
@@ -74,6 +59,14 @@ extension Application {
         public func use<S:Server>(_ makeServer: @escaping (Application) -> (S)) {
             guard !self.storage.servers.contains(where: { $0.key == S.key }) else { self.application.logger.warning("`\(S.key)` Server Already Installed - Skipping"); return }
             self.storage.servers.append( (S.key, makeServer(self.application)) )
+        }
+        
+        public func server<S:Server>(for sec:S.Type) -> S? {
+            self.server(forKey: sec.key) as? S
+        }
+        
+        public func server(forKey key:String) -> Server? {
+            self.storage.servers.first(where: { $0.key == key })?.value
         }
         
         public var available:[String] {

--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -10,18 +10,37 @@ extension Application {
         .init(application: self)
     }
 
-    public var server: Server {
-        guard let makeServer = self.servers.storage.makeServer else {
-            fatalError("No server configured. Configure with app.servers.use(...)")
-        }
-        return makeServer(self)
+    /// Conforms to Libp2p listen protocol
+    ///
+    /// - Note: This is the same as using app.servers.use(...)
+    public func listen(_ serverProvider:Servers.Provider) {
+        self.servers.use(serverProvider)
+    }
+    
+//    public var server: Server {
+//        guard let makeServer = self.servers.storage.makeServer else {
+//            fatalError("No server configured. Configure with app.servers.use(...)")
+//        }
+//        return makeServer(self)
+//    }
+    
+    public func server<S:Server>(for sec:S.Type) -> S? {
+        self.server(forKey: sec.key) as? S
+    }
+    
+    public func server(forKey key:String) -> Server? {
+        self.servers.storage.servers.first(where: { $0.key == key })?.value
     }
     
     public var listenAddresses:[Multiaddr] {
-        [self.server.listeningAddress]
+        self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
+            partialResult.append(server.listeningAddress)
+        }
     }
 
     public struct Servers {
+        typealias KeyedServer = (key: String, value: Server)
+        
         public struct Provider {
             let run: (Application) -> ()
 
@@ -35,7 +54,8 @@ extension Application {
         }
 
         final class Storage {
-            var makeServer: ((Application) -> Server)?
+            var servers:[KeyedServer] = []
+            //var makeServer: ((Application) -> Server)?
             init() { }
         }
 
@@ -50,13 +70,18 @@ extension Application {
         public func use(_ provider: Provider) {
             provider.run(self.application)
         }
-
-        public func use(_ makeServer: @escaping (Application) -> (Server)) {
-            self.storage.makeServer = makeServer
+        
+        public func use<S:Server>(_ makeServer: @escaping (Application) -> (S)) {
+            guard !self.storage.servers.contains(where: { $0.key == S.key }) else { self.application.logger.warning("`\(S.key)` Server Already Installed - Skipping"); return }
+            self.storage.servers.append( (S.key, makeServer(self.application)) )
         }
         
-        public var available:[Server] {
-            [self.application.server]
+        public var available:[String] {
+            self.storage.servers.map { $0.key }
+        }
+        
+        internal var allServers:[Server] {
+            self.storage.servers.map { $0.value }
         }
         
         public var command: ServeCommand {

--- a/Sources/LibP2P/Servers/Server.swift
+++ b/Sources/LibP2P/Servers/Server.swift
@@ -7,6 +7,8 @@
 
 // TODO: Remove these deprecated methods along with ServerStartError in the major release.
 public protocol Server: LifecycleHandler {
+    static var key:String { get }
+    
     var onShutdown: EventLoopFuture<Void> { get }
     
     /// Start the server with the specified address.

--- a/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
+++ b/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
@@ -10,6 +10,7 @@ import NIOExtras
 import Logging
 
 public final class TCPServer: Server {
+    public static var key:String = "TCP"
     
     /// Engine server config struct.
     ///


### PR DESCRIPTION
## Multiple Servers
Updated the Application+Servers storage to support multiple servers. The Server protocol now enforces a static Key that prevents multiple servers of the same type from being instantiated and installed on the app at the same time. 

### Installing/registering servers works via 
``` swift 
app.servers.use(.tcp)
/// or with the listen shortcut
app.listen(.ws(host: ..., port: ...))
``` 

### You can access a specific transports server via 
``` swift 
app.servers.server(for: TCPServer.self)
```  
### Note: The ```serve``` command needs some TLC to reflect the multiple server use case now.

### Note: This hasn't been extensively tested. But seems to work internally (swift-swift) and externally with (swift-go) & (swift-js). 