### PR TITLE
Connections, ConnectionManager, PeerStore and Misc Improvements

### DIFF
--- a/Sources/LibP2P/Connections/ARCConnection.swift
+++ b/Sources/LibP2P/Connections/ARCConnection.swift
@@ -1,0 +1,740 @@
+//
+//  ARCConnection.swift
+//
+//
+//  Created by Brandon Toms on 5/1/22.
+//
+
+import LibP2PCore
+import Logging
+import Foundation
+
+/// Esentially a BasicConnectionLight but adds support for Automatic Reference (Stream) Counting and closes / deinits itself when the connection is idle and empty for a given amount of time.
+public class ARCConnection:AppConnection {
+    
+    public var application:Application
+    
+    public var channel: Channel
+    private var eventLoop:EventLoop {
+        self.channel.eventLoop
+    }
+
+    public var id: UUID
+
+    public var localAddr: Multiaddr?
+
+    public var remoteAddr: Multiaddr?
+
+    public var localPeer: PeerID
+
+    public var remotePeer: PeerID?
+    
+    public var expectedRemotePeer: PeerID?
+
+    public var stats: ConnectionStats
+
+    public var tags: Any? = nil
+
+    public private(set) var registry: [UInt64 : LibP2PCore.Stream] = [:]
+    
+    public var streams: [LibP2PCore.Stream] {
+        //self.registry.map { $0.value }
+        self.muxer?.streams ?? []
+    }
+
+    public weak var muxer: Muxer? = nil
+    
+    public var isMuxed: Bool = false
+
+    public var status: ConnectionStats.Status {
+        self.stats.status
+    }
+
+    public var timeline:[ConnectionStats.Status:Date] {
+        self.stats.timeline.history
+    }
+    
+    struct StreamStateEntry {
+        let proto:String
+        let direction:ConnectionStats.Direction
+        let state:StreamState
+        let date:Date
+    }
+    internal private(set) var streamHistory:[StreamStateEntry] = []
+        
+    private var stateMachine:ConnectionStateMachine
+    public var state:ConnectionState {
+        self.stateMachine.state
+    }
+    
+    /// This is called when a remote peer is initiating a new stream
+    public var inboundMuxedChildChannelInitializer: ((Channel) -> EventLoopFuture<Void>)? = nil
+    /// This is called when we're initiating a new stream for a particular protocol
+    public var outboundMuxedChildChannelInitializer: ((Channel, String) -> EventLoopFuture<Void>)? = nil
+    
+    /// Our Connections Logger
+    public var logger:Logger
+    
+    /// These promises are used only once...
+    private var securedPromise:EventLoopPromise<SecuredResult>
+    private var muxedPromise:EventLoopPromise<Muxer>
+    
+    /// The timestamp at which this connection was instantiated
+    private var startTime:UInt64
+    
+    /// The IdleTimeout Task that gets set each time our connection gets to zero (0) open streams.
+    /// We wait `idleTimeoutMilliseconds` for a new Stream to be opened. If one isn't opened in that window, the connection shuts down and deinits itself.
+    private var idleTimeoutTask:Scheduled<Void>? = nil
+    /// The time in milliseconds that our connection will sit idle before terminating itself.
+    private var idleTimeoutMilliseconds:Int64 = 250
+    
+    public required init(application:Application, channel: Channel, direction: ConnectionStats.Direction, remoteAddress: Multiaddr, expectedRemotePeer: PeerID?) {
+        let id = UUID()
+        self.id = id
+        self.application = application
+        self.logger = Logger(label: "ARCConnection[\(application.peerID.shortDescription)][\(id.uuidString.prefix(5))]") //logger
+        self.logger.logLevel = application.logger.logLevel
+        self.channel = channel
+        self.stateMachine = ConnectionStateMachine()
+        
+        // Addresses
+        self.localAddr = try? channel.localAddress?.toMultiaddr()
+        self.remoteAddr = remoteAddress
+        
+        // Peers
+        self.localPeer = application.peerID
+        self.remotePeer = nil
+        self.expectedRemotePeer = expectedRemotePeer
+        
+        /// Metadata
+        self.registry = [:]
+        self.tags = nil
+        self.stats = ConnectionStats(uuid: id, direction: direction)
+        
+        /// State Promises
+        self.securedPromise = self.channel.eventLoop.makePromise(of: SecuredResult.self)
+        self.muxedPromise = self.channel.eventLoop.makePromise(of: Muxer.self)
+        
+        self.startTime = DispatchTime.now().uptimeNanoseconds
+        
+        /// Append an eventbus notification onto our parent channel's close future
+        self.channel.closeFuture.whenComplete { [weak self] res in
+            guard let self = self else { return }
+            self.logger.trace("ARCConnection:CloseFuture")
+            self.stats.status = .closed
+            
+            /// Should ensure that we actually connected before posting a disconnect event
+            if self.application.isRunning {
+                self.application.events.post(.disconnected(self, self.remotePeer))
+                //self.application.events.unregister(self)
+            }
+            
+            self.muxer = nil
+            self.inboundMuxedChildChannelInitializer = nil
+            self.outboundMuxedChildChannelInitializer = nil
+        }
+        
+        self.logger.trace("Initialized")
+    }
+    
+    deinit {
+        /// We had a leaking promise get triggered here... When our connection deinitializes before the securedPromise / muxedPromise are completed...
+        self.securedPromise.fail(Application.Connections.Errors.timedOut)
+        self.muxedPromise.fail(Application.Connections.Errors.timedOut)
+        self.logger.trace("Deinitialized")
+    }
+
+    /// This method is called immediately after a new Connection is instantiated with a channel (either inbound server, or outbound client)
+    /// This method should handle initializing the newly created Channel by configuring the channels pipeline with the appropriate channel handlers
+    /// This method should return quickly (as soon as pipeline configuration is complete)
+    public func initializeChannel() -> EventLoopFuture<Void> {
+        /// Add our future result handlers to our Connections state change promises
+        self.securedPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self else { return }
+            self.onSecured(result)
+        }
+        
+        self.muxedPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self else { return }
+            self.onMuxed(result)
+        }
+        
+        self.stats.status = .opening
+        
+        /// Kickoff security upgrade (also responsible for negotiation)
+        return self.secureConnection(promise: self.securedPromise).always { [weak self] _ in
+            guard let self = self else { return }
+            self.stats.status = .open
+        }
+    }
+    
+    /// Called by our Muxer when a stream of ours has been closed.
+    /// - Note: We take this opportunity to check if there are any active streams and kick off our idleTimeoutTask if there isn't.
+    private func onStreamClosed(_ stream:LibP2PCore.Stream) -> Void {
+        self.logger.trace("On Stream Closed...")
+        if self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty {
+            self.logger.trace("No Pending Streams")
+        }
+        if let mux = self.muxer, mux.streams.isEmpty {
+            self.logger.trace("No Streams")
+            if self.idleTimeoutTask != nil { return }
+            self.idleTimeoutTask = self.eventLoop.scheduleTask(in: .milliseconds(self.idleTimeoutMilliseconds)) {
+                /// Ask our connection manager to terminate us...
+                //self.application.connections.closeConnection(self)
+                /// Or close ourselves and notify our connection manager
+                self.logger.trace("Idle timeout reached. Terminating self")
+                let _ = self.close()
+            }
+        } else if let mux = self.muxer {
+            self.logger.trace("We still have \(mux.streams.count) streams")
+            self.logger.trace("\(mux.streams.map { "Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)][\($0.streamState)]" }.joined(separator: "\n") )")
+        } else {
+            self.logger.trace("No Muxer Available")
+        }
+    }
+    
+    /// Called by our Muxer when a new stream has been opened
+    /// - Note: We take this opportunity to cancel the idleTimeoutTask if one exists.
+    private func onNewStream(_ stream:LibP2PCore.Stream) -> Void {
+        if let idleTimeoutTask = self.idleTimeoutTask {
+            idleTimeoutTask.cancel()
+            self.logger.trace("Notified of new stream, canceling existing idleTimeoutTask")
+        }
+    }
+    
+    private func onSecured(_ result:Result<SecuredResult, Error>) {
+        switch result {
+        case .failure(let error):
+            self.logger.error("Failed to secure channel: \(error)")
+            self.channel.close(mode: .all, promise: nil)
+            return
+        case .success(let security):
+            do {
+                self.logger.info("Secured with `\(security.securityCodec)`! RemotePeer: \(String(describing: security.remotePeer)), Warnings: \(String(describing: security.warning))")
+                self.remotePeer = security.remotePeer
+                self.logger.info("Remote Address: \(self.remoteAddr?.description ?? "NIL")")
+                //self.logger.info("Remote Address: \(self.channel.remoteAddress), as Multiaddr: \(try? self.channel.remoteAddress?.toMultiaddr())")
+                //self.remoteAddr = try? self.channel.remoteAddress?.toMultiaddr()
+                try self.stateMachine.secureConnection()
+                self.stats.encryption = security.securityCodec
+                
+                if let rPeer = self.remotePeer, let rAddy = self.remoteAddr {
+                    let pInfo = PeerInfo(peer: rPeer, addresses: [rAddy])
+                    self.application.events.post(.remotePeer(pInfo))
+                } else {
+                    self.logger.warning("Post Security handshake without knowledge of RemotePeer and/or RemoteAddress")
+                }
+                
+                /// Kick off Muxer upgrade
+                self.muxConnection(promise: self.muxedPromise).whenComplete { res in
+                    switch res {
+                    case .failure(let error):
+                        self.logger.error("Failed to negotiate muxer: \(error)")
+                        self.channel.close(mode: .all, promise: nil)
+                        return
+                    case .success:
+                        self.logger.trace("Attempting to negotiate and install Muxer")
+                    }
+                }
+            } catch {
+                self.logger.error("Failed to secure channel: \(error)")
+                self.channel.close(mode: .all, promise: nil)
+                return
+            }
+        }
+    }
+    
+    private func onMuxed(_ result:Result<Muxer, Error>) {
+        switch result {
+        case .failure(let error):
+            self.logger.error("Failed to mux channel: \(error)")
+            self.channel.close(mode: .all, promise: nil)
+            return
+        case .success(let muxer):
+            do {
+                self.logger.info("Muxed with \(muxer)")
+                self.muxer = muxer
+                self.isMuxed = true
+                try self.stateMachine.muxConnection()
+                self.stats.status = .upgraded
+                self.stats.muxer = muxer.protocolCodec
+                
+                /// Callback handlers for ARC functionality
+                self.muxer?.onStream = self.onNewStream
+                self.muxer?.onStreamEnd = self.onStreamClosed
+                
+                let timeToUpgrade = DispatchTime.now().uptimeNanoseconds - self.startTime
+                self.logger.notice("Upgrade Time: \(timeToUpgrade / 1_000_000) ms")
+                
+                self.eventLoop.execute {
+                    /// Our connection is upgraded...
+                    self.logger.trace("Our connection has been Secured and Muxed! We're ready to rock!")
+                    self.application.events.post(.connected(self)) // Do we do this here? or earlier??
+                    self.application.events.post(.upgraded(self))
+                    
+                    /// Open any pending streams now that we're muxed
+                    ///
+                    /// TODO: Not sure about this error handling....
+                    self.pendingStreamCache.forEach { pendingStream in
+                        self.logger.debug("Asking Muxer to open / initialize pending stream for protocol `\(pendingStream.proto)`")
+                        self.newStreamCache.append(pendingStream)
+                        do {
+                            try muxer.newStream(channel: self.channel, proto: pendingStream.proto).whenComplete({ result in
+                                switch result {
+                                case .success:
+                                    break
+                                    
+                                case .failure(let error):
+                                    let errorRequest = Request(application: self.application, event: .error(error), streamDirection: .outbound, connection: self, channel: self.channel, logger: self.logger, on: self.channel.eventLoop)
+                                    let _ = pendingStream.responder.respond(to: errorRequest)
+                                }
+                            })
+                        } catch {
+                            let errorRequest = Request(application: self.application, event: .error(error), streamDirection: .outbound, connection: self, channel: self.channel, logger: self.logger, on: self.channel.eventLoop)
+                            let _ = pendingStream.responder.respond(to: errorRequest)
+                        }
+                    }
+                    self.pendingStreamCache = []
+                }
+                
+            } catch {
+                self.logger.error("Failed to mux channel: \(error)")
+                self.channel.close(mode: .all, promise: nil)
+                return
+            }
+        }
+    }
+    
+    /// This function gets called by our Muxer when instantiating a new inbound child Channel
+    /// Take this opportunity to configure the child channels pipeline before data transmission begins
+    public func inboundMuxedChildChannelInitializer(_ childChannel:Channel) -> EventLoopFuture<Void> {
+        let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+        //let log = Logger(label: self.logger.label + " : Stream[\(0)][Inbound]")
+        let mssHandlers:[ChannelHandler] = self.application.upgrader.negotiate(protocols: self.application.routes.all.map { $0.description }, mode: .listener, logger: logger, promise: negotiationPromise)
+
+        negotiationPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self, self.application.isRunning else { return }
+            switch result {
+            case .failure(let error):
+                self.muxer?.removeStream(channel: childChannel)
+                self.logger.error("Error while upgrading Inbound ChildChannel: \(error)")
+                
+            case .success(let proto):
+                /// Append a stream event in our stream history array
+                self.streamHistory.append(StreamStateEntry(proto: proto.protocol.description, direction: .inbound, state: .initialized, date: Date()))
+                
+                self.upgradeChildChannel(proto, childChannel: childChannel, responder: self.application.responder.current, direction: .inbound).whenComplete { [weak self] result in
+                    guard let self = self, self.application.isRunning else { return }
+                    
+                    /// Append a stream event in our stream history array
+                    self.streamHistory.append(StreamStateEntry(proto: proto.protocol, direction: .inbound, state: .open, date: Date()))
+                    
+                    self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
+                    self.logger.debug("🔀 New Inbound ChildChannel[`\(proto)`] Ready!")
+                    self.logger.trace("List of Streams:")
+                    self.logger.trace("\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))")
+                    // Post about the new stream on our applications Event Bus
+                    if case .success = result {
+                        guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
+                        str._connection = self
+                        self.application.events.post(.openedStream(str))
+                        childChannel.closeFuture.whenComplete { [weak self] _ in
+                            guard let self = self else { return }
+                            /// Append a stream event in our stream history array
+                            self.streamHistory.append(StreamStateEntry(proto: proto.protocol, direction: .inbound, state: .closed, date: Date()))
+                            self.application.events.post(.closedStream(str))
+                        }
+                    }
+                }
+            }
+        }
+        return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+    }
+    
+    /// This function gets called by our Muxer when instantiating a new outbound child Channel
+    /// Take this opportunity to configure the child channels pipeline for the specified protocol before data transmission beings
+    public func outboundMuxedChildChannelInitializer(_ childChannel:Channel, protocol:String) -> EventLoopFuture<Void> {
+        self.eventLoop.flatSubmit {
+            guard let idx = self.newStreamCache.firstIndex(where: { $0.proto == `protocol`}) else {
+                self.logger.error("No Responder For `\(`protocol`)`")
+                self.logger.error("\(self.newStreamCache)")
+                return childChannel.eventLoop.makeFailedFuture(Application.Connections.Errors.noResponder)
+            } //?? self.application.responder.current
+            let pendingStream = self.newStreamCache.remove(at: idx)
+            let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+            //let log = Logger(label: self.logger.label + " : Stream[\(1)][Outbound]")
+            let mssHandlers:[ChannelHandler] = self.application.upgrader.negotiate(protocols: [`protocol`], mode: .initiator, logger: self.logger, promise: negotiationPromise)
+
+            negotiationPromise.futureResult.whenComplete { [weak self] result in
+                guard let self = self, self.application.isRunning else { return }
+                switch result {
+                case .failure(let error):
+                    self.muxer?.removeStream(channel: childChannel)
+                    self.logger.error("Error while upgrading Outbound ChildChannel: \(error)")
+                case .success(let proto):
+                    /// Append a stream event in our stream history array
+                    self.streamHistory.append(StreamStateEntry(proto: proto.protocol.description, direction: .outbound, state: .initialized, date: Date()))
+                    
+                    self.upgradeChildChannel(proto, childChannel: childChannel, responder: pendingStream.responder, direction: .outbound).whenComplete { [weak self] result in
+                        guard let self = self, self.application.isRunning else { return }
+                        
+                        /// Append a stream event in our stream history array
+                        self.streamHistory.append(StreamStateEntry(proto: proto.protocol, direction: .outbound, state: .open, date: Date()))
+                        
+                        self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
+                        self.logger.debug("🔀 New Outbound ChildChannel[`\(proto)`] Ready!")
+                        self.logger.trace("List of Streams:")
+                        self.logger.trace("\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))")
+                        // Post about the new stream on our applications Event Bus
+                        if case .success = result {
+                            guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
+                            str._connection = self
+                            self.application.events.post(.openedStream(str))
+                            childChannel.closeFuture.whenComplete { [weak self] _ in
+                                guard let self = self else { return }
+                                /// Append a stream event in our stream history array
+                                self.streamHistory.append(StreamStateEntry(proto: proto.protocol, direction: .outbound, state: .closed, date: Date()))
+                                self.application.events.post(.closedStream(str))
+                            }
+                        }
+                    }
+                }
+            }
+            return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+        }
+    }
+    
+    /// To be called when the childChannel's protocol negotiation completes
+    ///
+    /// Note: Also is responsible for forwarding any leftover bytes received during the childChannel upgrade process
+    private func upgradeChildChannel(_ proto:NegotiationResult, childChannel:Channel, responder:Responder, direction:ConnectionStats.Direction) -> EventLoopFuture<Void> {
+        //Install the protocol on the channels pipeline...
+        logger.trace("Negotiated \(proto)")
+        guard var handlers = responder.pipelineConfig(for: proto.protocol, on: self) else {
+            /// Unhandled protocol negotiated
+            logger.trace("Unhandled protocol negotiated `\(proto.protocol)`")
+            return childChannel.eventLoop.makeSucceededVoidFuture()
+        }
+        logger.trace("Attempting to install route (`\(proto)`) specific ChannelHandlers")
+        logger.trace("\(handlers.map({ String(describing: $0) }).joined(separator: ", "))")
+        //let log = Logger(label: self.logger.label + " : Stream[\(1)][Outbound]")
+        
+        handlers.append(contentsOf: [
+            RequestEncoderChannelHandler(application: application, connection: self, protocol: proto.protocol, logger: logger, direction: direction),
+            ResponseDecoderChannelHandler(logger: logger),
+            ResponderChannelHandler(responder: responder, logger: logger)
+        ] as [ChannelHandler])
+        
+        return muxer!.updateStream(channel: childChannel, state: .open, proto: proto.protocol).flatMap {
+            childChannel.pipeline.addHandlers(handlers, position: .last).flatMap {
+                childChannel.pipeline.removeHandler(name: "upgrader").flatMap {
+                    if let lo = proto.leftoverBytes, lo.readableBytes > 0 {
+                        guard childChannel.isWritable else {
+                            self.logger.error("Failed to forward leftover bytes along pipeline")
+                            return childChannel.eventLoop.makeSucceededVoidFuture()
+                        }
+                        self.logger.trace("Forwarding leftover bytes along pipeline...")
+                        childChannel.pipeline.fireChannelRead( NIOAny(proto.leftoverBytes) )
+                    }
+                    return childChannel.eventLoop.makeSucceededVoidFuture()
+                }
+            }
+        }
+    }
+    
+    public func newStream(_ protos: [String]) -> EventLoopFuture<LibP2PCore.Stream> {
+        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
+    
+    public enum NewStreamMode {
+        case openStream
+        case ifOneDoesntAlreadyExist
+        case ifOutboundDoesntAlreadyExist
+    }
+    
+    private struct StreamCache {
+        let proto:String
+        let responder:Responder
+        
+        init(proto:String, responder:Responder) {
+            self.proto = proto
+            self.responder = responder
+        }
+    }
+    
+    private var newStreamCache:[StreamCache] = []
+    private var pendingStreamCache:[StreamCache] = []
+    /// Opens an outbound stream delegating to a uniquely specified handler / responder
+    public func newStream(forProtocol proto: String, withHandlers:HandlerConfig = .rawHandlers([]), andMiddleware:MiddlewareConfig = .custom(nil), closure: @escaping ((Request) throws -> EventLoopFuture<RawResponse>)) {
+        
+        self.logger.trace("Constructing Responder with Handlers: [\(withHandlers.handlers(application: self.application, connection: self, forProtocol: proto))]")
+        
+        self.newStream(
+            forProtocol: proto,
+            withResponder: BasicResponder(
+                closure: closure,
+                handlers: withHandlers.handlers(application: self.application, connection: self, forProtocol: proto)
+            )
+        )
+    }
+    /// Opens an outbound stream delegating to our registered Route handler instead of a uniquely specified handler / responder
+    public func newStream(forProtocol proto: String) {
+        self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+    }
+    
+    public func newStream(forProtocol proto: String, mode: NewStreamMode = .openStream) {
+        switch mode {
+        case .openStream:
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        case .ifOneDoesntAlreadyExist:
+            guard self.hasStream(forProtocol: proto, direction: nil) == nil else { return }
+            guard !self.pendingStreamCache.contains(where: { $0.proto == proto }) else { return }
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        case .ifOutboundDoesntAlreadyExist:
+            guard self.hasStream(forProtocol: proto, direction: .outbound) == nil else { return }
+            guard !self.pendingStreamCache.contains(where: { $0.proto == proto }) else { return }
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        }
+    }
+    
+    private func newStream(forProtocol proto:String, withResponder responder:Responder) {
+        let pendingStream = StreamCache(
+            proto: proto,
+            responder: responder
+        )
+        
+        self.eventLoop.execute {
+            /// Ask our muxer to open the stream...
+            if self.isMuxed, let mux = self.muxer {
+                /// Store our responder
+                self.logger.trace("Adding `\(proto)` to our newStreamCache")
+                self.newStreamCache.append( pendingStream )
+                /// Ask our installed Muxer to open / initialize a new stream for us...
+                self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
+                try! mux.newStream(channel: self.channel, proto: proto).whenSuccess { stream in
+                    //print("Skipping Stream Registry")
+                    //self.registry[stream.id] = stream
+                }
+                
+            } else {
+                /// Store our responder
+                self.logger.trace("Adding `\(proto)` to our pendingStreamCache")
+                self.pendingStreamCache.append( pendingStream )
+            }
+        }
+    }
+    
+    public func newStreamSync(_ proto: String ) throws -> LibP2PCore.Stream {
+        let stream:_Stream
+        if isMuxed, let mux = self.muxer {
+            // Ask our installed Muxer to open / initialize a new stream for us...
+            self.logger.debug("Asking Muxer to open / initialize new stream")
+            stream = try mux.newStream(channel: self.channel, proto: proto).wait()
+        } else {
+            // Initialize a Stream to be opened once our Muxer is installed...
+            self.logger.debug("TODO: Store new stream to be open later, once a muxer has been installed")
+            //stream = MplexStream(channel: self.channel, mode: .initiator, id: 0, name: "\(id)", proto: proto, streamState: .initialized)
+            throw Application.Connections.Errors.notImplementedYet
+        }
+        
+        stream._connection = self
+        
+        self.registry[stream.id] = stream
+        
+        //stream.on = self.delegate?.onStreamEvent
+        
+        //let _ = eventLoop.submit { () -> Void in
+        //    self._registry[stream.id] = stream
+        //}
+        
+        return stream
+        
+        //throw Errors.notImplementedYet
+    }
+
+    public func newStreamHandlerSync(_ proto: String) throws -> StreamHandler {
+        throw Application.Connections.Errors.notImplementedYet
+    }
+
+    public func removeStream(id: UInt64) -> EventLoopFuture<Void> {
+        if let stream = self.registry.removeValue(forKey: id) {
+            /// Append a stream event in our stream history array
+            //self.streamHistory.append(StreamStateEntry(proto: stream.protocolCodec, id: Int(id), state: .closed, date: Date()))
+            return stream.close(gracefully: true)
+        } else {
+            return self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.noStreamForID(id))
+        }
+    }
+
+    public func acceptStream(_ stream: LibP2PCore.Stream, protocol: String, metadata: [String]) -> EventLoopFuture<Bool> {
+        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
+
+    public func hasStream(forProtocol proto:String, direction:ConnectionStats.Direction? = nil) -> LibP2PCore.Stream? {
+        if let direction = direction {
+            return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) && ($0.direction == direction) })
+        } else {
+            return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) })
+        }
+    }
+    
+    /// Called as soon as there is a request to close the Connection (internally via the connection manager, or externally via the user)
+    internal func onClosing() -> EventLoopFuture<Void> {
+        eventLoop.submit {
+            self.stats.status = .closing
+            self.logger.trace("Closing")
+        }
+//        .flatMap {
+//            /// if we have a muxer, close all streams...
+//            self.muxer?.streams.map { str in
+//                str.reset()
+//            }.flatten(on: self.channel.eventLoop) ?? self.eventLoop.makeSucceededVoidFuture()
+//        }
+    }
+    
+    public func close() -> EventLoopFuture<Void> {
+        //self.channel.close(mode: .all)
+        self.registry = [:]
+        self.logger.trace("Close called, attempting to close all streams before shutting down the channel.")
+        return eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
+            self.onClosing().flatMap { () -> EventLoopFuture<Void> in
+                let closePromise = self.eventLoop.makePromise(of: Void.self)
+                let timeout = self.eventLoop.scheduleTask(in: .seconds(1)) {
+                    closePromise.fail(Application.Connections.Errors.failedToCloseAllStreams)
+                }
+                
+                closePromise.completeWith (
+                    self.streams.map { $0.close(gracefully: false) }.flatten(on: self.eventLoop).flatMapAlways { result -> EventLoopFuture<Void> in
+                        timeout.cancel()
+                        switch result {
+                        case .failure(let err):
+                            self.logger.error("Error encountered while attempting to close streams: \(err)")
+                            return self.eventLoop.makeFailedFuture(Application.Connections.Errors.failedToCloseAllStreams)
+                        case .success:
+                            return self.streams.compactMap {
+                                switch $0.streamState {
+                                case .closed, .reset:
+                                    return nil
+                                default:
+                                    // Ensure we fire our close event before
+                                    // TODO: Silently force close the stream...
+                                    self.logger.warning("Force Closing Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)]")
+                                    return $0.on?(.closed)
+                                }
+                            }.flatten(on: self.eventLoop)
+                        }
+                    }
+                )
+                
+                return closePromise.futureResult.flatMapAlways { res in
+                    self.stats.status = .closed
+                    switch res {
+                    case .success:
+                        self.logger.trace("All Streams closed cleanly")
+                    case .failure:
+                        self.logger.warning("Failed to close all Streams cleanly")
+                    }
+                    // Do any additional clean up before closing / deiniting self...
+                    self.logger.trace("Proceeding to close Connection")
+                    return self.channel.close(mode: .all)
+                }
+            }
+        }
+    }
+}
+
+extension ARCConnection {
+    
+    public struct ConnectionStateMachine {
+        internal private(set) var state:ConnectionState
+        
+        internal init() {
+            self.state = .raw
+        }
+        
+        internal mutating func secureConnection() throws {
+            switch state {
+            case .raw:
+                self.state = .secured
+            case .secured, .muxed, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+        
+        internal mutating func muxConnection() throws {
+            switch state {
+            case .secured:
+                self.state = .muxed
+            case .raw, .muxed, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+        
+        internal mutating func upgradeConnection() throws {
+            switch state {
+            case .muxed:
+                self.state = .upgraded
+            case .raw, .secured, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+        
+        internal mutating func closeConnection() throws {
+            switch state {
+            case .closed:
+                print("Already closed")
+            case .raw, .secured, .muxed, .upgraded:
+                self.state = .closed
+            }
+        }
+    }
+    
+    internal enum StateTransitionError:Error {
+        case invalidStateTransition
+    }
+}
+
+extension ARCConnection {
+    public func lastActivity() -> Date {
+        guard !(self.status == .closed || self.status == .closing) else {
+            if let upgraded = self.stats.timeline.history.first(where: { $0.key == .upgraded } ) {
+                return upgraded.value
+            }
+            return Date.distantPast
+        }
+        let lastConnectionActivity = self.stats.timeline.history.max(by: { lhs, rhs in
+            lhs.value < rhs.value
+        })?.value
+        let lastStreamActivity = self.streamHistory.max(by: { lhs, rhs in
+            lhs.date < rhs.date
+        })?.date
+        
+        switch (lastConnectionActivity, lastStreamActivity) {
+        case (nil, nil):
+            return Date.distantPast
+        case (.some(let connActivity), nil):
+            return connActivity
+        case (nil, .some(let strActivity)):
+            return strActivity
+        case (.some(let connActivity), .some(let strActivity)):
+            return connActivity < strActivity ? strActivity : connActivity
+        }
+    }
+}
+
+extension ARCConnection {
+    public var description: String {
+        let header = "--- 🔁 \(self.direction == .inbound ? "Inbound" : "Outbound") Connection[\(self.id.uuidString.prefix(5))] 🔁 ---"
+        return """
+            \(header)
+            State: \(self.state) <\(self.status)>
+            Peer: \(self.remoteAddr?.description ?? "???") <\(self.remotePeer?.b58String ?? "???")>
+            Timeline:
+             - \(self.timeline.sorted(by: { $0.value < $1.value }).map { "\($0.value) - \($0.key)" }.joined(separator: "\n - "))
+            Streams: Open<\(self.streams.filter({ $0.streamState == .open }).count)>, Total<\(self.streams.count)>
+             - \(self.streamHistory.sorted(by: { $0.date < $1.date }).map { "[\($0.state)][\($0.direction)]\($0.proto) @ \($0.date.timeIntervalSince1970)" }.joined(separator: "\n - "))
+            Last Activity: \(self.lastActivity())
+            \(String(repeating: "-", count: header.count + 2))\n
+            """
+    }
+}

--- a/Sources/LibP2P/Connections/AppConnection.swift
+++ b/Sources/LibP2P/Connections/AppConnection.swift
@@ -1,0 +1,132 @@
+//
+//  AppConnection.swift
+//
+//
+//  Created by Brandon Toms on 10/18/22.
+//
+
+/// AppConnection Protocol
+///
+/// - Note: Our Connection Protocol is defined in LibP2PCore where we don't have access to Application specific structs, classes and protocols. Therefore we extend the core Connection protocol with some handy features available at the Application Layer
+public protocol AppConnection:Connection, CustomStringConvertible {
+    var application:Application { get }
+    var logger:Logger { get }
+    
+    init(application:Application, channel: Channel, direction: ConnectionStats.Direction, remoteAddress:Multiaddr, expectedRemotePeer:PeerID?)
+    
+    func initializeChannel() -> EventLoopFuture<Void>
+    
+    //func newStream(forProtocol proto:String, withResponder responder:Responder)
+    func newStream(forProtocol proto: String, withHandlers: HandlerConfig, andMiddleware: MiddlewareConfig, closure: @escaping ((Request) throws -> EventLoopFuture<RawResponse>))
+    
+    func lastActivity() -> Date
+}
+
+extension AppConnection {
+    
+    /// This method returns immediately after installing the upgrader and completes a promise upon protocol negotiation
+    internal func negotiateProtocol(fromSet protocols:[String], mode: LibP2P.Mode, logger: Logger, promise:EventLoopPromise<NegotiationResult>) -> EventLoopFuture<Void> {
+        let mssHandlers:[ChannelHandler] = application.upgrader.negotiate(protocols: protocols, mode: mode, logger: logger, promise: promise)
+        return self.channel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+    }
+    
+    /// Satisifies the Promise by Negotiating and installing a Security Module
+    /// - Note: this method returns immediately after installing the negotiation ChannelHandlers
+    internal func secureConnection(promise:EventLoopPromise<SecuredResult>) -> EventLoopFuture<Void> {
+        let negotiationPromise = self.channel.eventLoop.makePromise(of: NegotiationResult.self)
+        
+        negotiationPromise.futureResult.whenComplete { res in
+            switch res {
+            case .failure(let error):
+                promise.fail(error)
+            case .success(let negotiated):
+                guard let secUpgrader = self.application.security.upgrader(forKey: negotiated.protocol) else {
+                    promise.fail(Application.Connections.Errors.invalidProtocolNegotatied)
+                    return
+                }
+                
+                // - TODO: we might want to be more specific here with the position we're adding our handlers...
+                secUpgrader.upgradeConnection(self, position: .last, securedPromise: promise).flatMap {
+                    self.channel.pipeline.removeHandler(name: "upgrader")
+                }.whenComplete { res in
+                    switch res {
+                    case .failure(let error):
+                        promise.fail(error)
+                    case .success:
+                        self.logger.trace("Upgrader Removed Successfully")
+                    }
+                }
+            }
+        }
+        
+        return negotiateProtocol(fromSet: self.application.security.available, mode: self.mode, logger: logger, promise: negotiationPromise)
+    }
+    
+    /// Satisifies the Promise by Negotiating and installing a Muxer
+    /// - Note: this method returns immediately after installing the negotiation ChannelHandlers
+    internal func muxConnection(promise:EventLoopPromise<Muxer>) -> EventLoopFuture<Void> {
+        let negotiationPromise = self.channel.eventLoop.makePromise(of: NegotiationResult.self)
+        //let muxedPromise = self.channel.eventLoop.makePromise(of: Muxer.self)
+        
+        negotiationPromise.futureResult.whenComplete { res in
+            switch res {
+            case .failure(let error):
+                promise.fail(error)
+            case .success(let negotiated):
+                guard let muxUpgrader = self.application.muxers.upgrader(forKey: negotiated.protocol) else {
+                    promise.fail(Application.Connections.Errors.invalidProtocolNegotatied)
+                    return
+                }
+            
+                muxUpgrader.upgradeConnection(self, muxedPromise: promise).flatMap {
+                    self.channel.pipeline.removeHandler(name: "upgrader")
+                }.whenComplete { res in
+                    switch res {
+                    case .failure(let error):
+                        promise.fail(error)
+                    case .success:
+                        self.logger.trace("Upgrader Removed Successfully")
+                    }
+                }
+            }
+        }
+        
+        return negotiateProtocol(fromSet: self.application.muxers.available, mode: self.mode, logger: logger, promise: negotiationPromise)
+    }
+}
+
+//extension Connection {
+//    /// TODO: Actually implement this....
+//    public func close() -> EventLoopFuture<Void> {
+//        self.logger.trace("Close called, attempting to close all streams before shutting down the channel.")
+//        return channel.eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
+//            //self.onClosing().flatMap { () -> EventLoopFuture<Void> in
+//                return self.streams.map { $0.close(gracefully: true) }.flatten(on: self.channel.eventLoop).flatMapAlways { result -> EventLoopFuture<Void> in
+//                    switch result {
+//                    case .failure(let err):
+//                        self.logger.error("Error encountered while attempting to close streams: \(err)")
+//                        //return self.channel.eventLoop.makeFailedFuture(Errors.failedToCloseAllStreams)
+//                        return self.channel.eventLoop.makeFailedFuture(NSError(domain: "Failed To Close All Streams", code: 0))
+//                    case .success:
+//                        return self.streams.compactMap {
+//                            switch $0.streamState {
+//                            case .closed, .reset:
+//                                return nil
+//                            default:
+//                                // Ensure we fire our close event before
+//                                // TODO: Silently force close the stream...
+//                                return $0.on?(.closed)
+//                            }
+//                        }.flatten(on: self.channel.eventLoop).flatMapAlways { result -> EventLoopFuture<Void> in
+//                            self.logger.trace("Streams closed")
+//                            // Do any additional clean up before closing / deiniting self...
+//                            self.logger.trace("Proceeding to close Connection")
+//                            return self.channel.close(mode: .all)
+//                        }
+//                    }
+//                }
+//            //}
+//        }
+//    }
+//}
+

--- a/Sources/LibP2P/Connections/Application+Connections+Methods.swift
+++ b/Sources/LibP2P/Connections/Application+Connections+Methods.swift
@@ -60,7 +60,7 @@ extension Application {
         let promise = on.makePromise(of: [Multiaddr].self)
         var dialableAddresses:[Multiaddr] = []
         
-        let _ = mas.map { ma in
+        let _ = Set(mas).map { ma in
             self.transports.canDial(ma, on: on).map { canDial in
                 if canDial {
                     if externalAddressesOnly {

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -1,9 +1,13 @@
 //
 //  Application+ConnectionManager.swift
-//  
+//
 //
 //  Created by Brandon Toms on 5/1/22.
 //
+
+import NIOCore
+import Multiaddr
+import LibP2PCore
 
 extension Application {
     public var connectionManager: Connections {
@@ -18,6 +22,15 @@ extension Application {
     }
     
     public struct Connections {
+        public enum Errors:Error {
+            case notImplementedYet
+            case invalidProtocolNegotatied
+            case noResponder
+            case failedToCloseAllStreams
+            case noStreamForID(UInt64)
+            case timedOut
+        }
+        
         public struct Provider {
             let run: (Application) -> ()
 
@@ -54,6 +67,11 @@ extension Application {
                 fatalError("ConnectionManager not initialized. Configure with app.connectionManager.initialize()")
             }
             return storage
+        }
+        
+        public func generateConnection(channel: Channel, direction: ConnectionStats.Direction, remoteAddress: Multiaddr, expectedRemotePeer: PeerID?) -> AppConnection {
+            return ARCConnection(application: application, channel: channel, direction: direction, remoteAddress: remoteAddress, expectedRemotePeer: expectedRemotePeer)
+            //return BasicConnectionLight(application: application, channel: channel, direction: direction, remoteAddress: remoteAddress, expectedRemotePeer: expectedRemotePeer)
         }
     }
 }

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultConnectionManager.swift
-//  
+//
 //
 //  Created by Brandon Toms on 5/1/22.
 //
@@ -22,7 +22,11 @@ class BasicInMemoryConnectionManager:ConnectionManager {
     /// RemoteAddress (String) : [Connection]
     private var connections:[String:Connection]
     
+    /// A dictionary keyed by the RemotePeer's b58String containing a list of ConnectionStats (one for each connection established to the peer)
     private var connectionHistory:[String:[ConnectionStats]] = [:]
+    
+    /// Connection Stream ARC Counter
+    private var connectionStreamCount:[String:Int] = [:]
     
     /// The max number of connections we can have open at any given time
     private var maxPeers:Int
@@ -33,7 +37,14 @@ class BasicInMemoryConnectionManager:ConnectionManager {
     /// This Logger
     private var logger:Logger
     
-    internal init(application:Application, maxPeers:Int = 25) {
+    /// The minimum Idle connection time
+    private let minExpiration:Int = 3
+    /// The maximum Idle connection time
+    private let maxExpiration:Int = 30
+    /// The inbound vs outbound buffer
+    private var buffer:Int
+    
+    internal init(application:Application, maxPeers:Int = 50) {
         self.application = application
         self.eventLoop = application.eventLoopGroup.next()
         self.logger = application.logger
@@ -41,9 +52,12 @@ class BasicInMemoryConnectionManager:ConnectionManager {
 
         self.connections = [:]
         self.maxPeers = maxPeers
+        self.buffer = Int(Double(maxPeers) * 0.2)
         
         /// Subscribe to onDisconnect events
         self.application.events.on(self, event: .disconnected( onDisconnectedNew ))
+        self.application.events.on(self, event: .openedStream( onOpenedStream ))
+        self.application.events.on(self, event: .closedStream( onClosedStream ))
         
         self.logger.trace("Initialized")
     }
@@ -51,6 +65,7 @@ class BasicInMemoryConnectionManager:ConnectionManager {
     func setMaxConnections(_ maxConnections:Int) {
         let _ = self.eventLoop.submit {
             self.maxPeers = maxConnections
+            self.buffer = Int(Double(maxConnections) * 0.2)
             self.logger.notice("Max Connections updated to \(maxConnections)")
         }
     }
@@ -77,7 +92,7 @@ class BasicInMemoryConnectionManager:ConnectionManager {
                 return .Connected
             } else {
                 if let existing = self.connectionHistory[peer.b58String] {
-                    if let mostRecent = existing.last, mostRecent.timeline.history.count >= 4 { //At least `opening -> open -> upgraded -> closed`
+                    if let mostRecent = existing.last, mostRecent.timeline.history.contains(where: { $0.key == .upgraded }) {
                         return .CanConnect
                     } else {
                         return .CanNotConnect
@@ -91,11 +106,51 @@ class BasicInMemoryConnectionManager:ConnectionManager {
     
     func addConnection(_ connection:Connection, on loop:EventLoop?) -> EventLoopFuture<Void> {
         eventLoop.submit { () in
-            guard self.connections.count < self.maxPeers else { throw Errors.tooManyPeers  }
+            if connection.direction == .inbound {
+                /// Allow inbound connections up until maxConnections - buffer  ( 100 - 20 )
+                guard self.connections.count < self.maxPeers - self.buffer else {
+                    self.logger.error("Preventing new \(connection.direction) connection due to max connection limit reached \(self.connections.count)")
+                    let _ = self.debouncedPrune()
+                    //self.dumpConnectionMetricsRandomSample()
+                    throw Errors.tooManyPeers
+                }
+            } else {
+                /// Allow outbound connections up until maxConnections ( 100 )
+                guard self.connections.count < self.maxPeers else {
+                    self.logger.error("Preventing new \(connection.direction) connection due to max connection limit reached \(self.connections.count)")
+                    let _ = self.debouncedPrune()
+                    //self.dumpConnectionMetricsRandomSample()
+                    throw Errors.tooManyPeers
+                }
+            }
             guard self.connections[connection.id.uuidString] == nil else { throw Errors.connectionAlreadyExists }
             self.connections[connection.id.uuidString] = connection
+            /// Kick off a prune if we're close to our max peer count
+            if self.connections.count > (self.maxPeers - self.buffer) { let _ = self.debouncedPrune() }
             return
         }.hop(to: loop ?? eventLoop)
+    }
+    
+    private func dumpConnectionMetricsRandomSample() {
+        let _ = eventLoop.submit {
+            self.logger.notice("Oldest 4 Connections")
+            self.logger.notice("Date: \(Date())")
+            let bcl:[AppConnection] = self.connections.compactMap { $0.value as? AppConnection }
+            bcl.sorted { lhs, rhs in
+                lhs.lastActivity() < rhs.lastActivity()
+            }.prefix(4).forEach {
+                self.logger.notice("\($0.id) -> \($0.lastActivity())")
+                if Date().timeIntervalSince1970 - $0.lastActivity().timeIntervalSince1970 > 5 {
+                    self.logger.notice("\($0.description)")
+                }
+                //self.logger.notice("Last Active: \($0.lastActivity())")
+                //self.logger.notice("\($0.streamHistory)")
+                //self.logger.notice("Stream Count::\($0.streams.count)")
+                //for stream in $0.streams {
+                //    self.logger.notice("[\(stream.id)]\(stream.protocolCodec)::\(stream.direction)::\(stream.streamState)")
+                //}
+            }
+        }
     }
     
     func closeConnectionsToPeer(peer: PeerID, on loop:EventLoop?) -> EventLoopFuture<Bool> {
@@ -128,7 +183,8 @@ class BasicInMemoryConnectionManager:ConnectionManager {
             $0.value.close()
         }.flatten(on: eventLoop).always { _ in
             self.connections.forEach {
-                self.connectionHistory[$0.key, default: []].append($0.value.stats)
+                guard let pid = $0.value.remotePeer else { return }
+                self.connectionHistory[pid.b58String, default: []].append($0.value.stats)
             }
             self.connections = [:]
         }
@@ -143,38 +199,151 @@ class BasicInMemoryConnectionManager:ConnectionManager {
     }
     
     private func pruneClosedConnections() -> EventLoopFuture<Void> {
-        eventLoop.submit { () in
-            self.connections.filter({ $0.value.status == .closed }).forEach {
-                if let conn = self.connections.removeValue(forKey: $0.key) {
-                    self.connectionHistory[$0.key, default: []].append( conn.stats )
-                }
-            }
-            return
+        eventLoop.flatSubmit { () in
+            self.connections.filter({ $0.value.status == .closed }).map {
+                return self.closeConnectionWithTimeout(id: $0.value.id)
+            }.flatten(on: self.eventLoop)
         }
     }
- 
+    
+    /// Removes connections that have 0 streams open.
+    private func pruneConnections() -> EventLoopFuture<Void> {
+        eventLoop.flatSubmit { () in
+            return self.connections.filter({ ($0.value.status == .upgraded || $0.value.status == .closing) && $0.value.streams.isEmpty }).map {
+                return self.closeConnectionWithTimeout(id: $0.value.id)
+            }.flatten(on: self.eventLoop)
+        }
+    }
+    
+    private func pruneOldConnections() -> EventLoopFuture<Void> {
+        return eventLoop.flatSubmit {
+            let factor = max(0.0, min(1.0, 1.0 - (Double(self.connections.count + self.buffer) / Double(self.maxPeers))))
+            let expiration = (factor * Double(self.maxExpiration - self.minExpiration)) + Double(self.minExpiration)
+            let expirationDate = Date().addingTimeInterval( -expiration )
+            let bcl:[AppConnection] = self.connections.compactMap { $0.value as? AppConnection }.filter { $0.lastActivity() < expirationDate }
+            self.logger.notice("Pruning \(bcl.count) Connections that are older than \(Int(expiration)) seconds")
+            return bcl.map { conn in
+                //self.logger.notice("Closing Old Connection[\(conn.id)][\(conn.remoteAddr?.description ?? "???")][\(conn.remotePeer?.description ?? "???")]")
+                return self.closeConnectionWithTimeout(id: conn.id)
+            }.flatten(on: self.eventLoop)
+        }
+    }
+
+    private func closeConnectionWithTimeout(id:UUID) -> EventLoopFuture<Void> {
+        self.eventLoop.submit {
+            guard let connection = self.connections[id.uuidString] else {
+                //self.logger.warning("Failed to find connection with id: \(id.uuidString) in connection database.")
+                return
+            }
+            let _ = connection.close()
+            let _ = self.removeConnectionFromList(id: id)
+        }
+    }
+    
+    private func removeConnectionFromList(id:UUID) -> EventLoopFuture<Void> {
+        self.eventLoop.submit {
+            if let c = self.connections.removeValue(forKey: id.uuidString) {
+                if let pid = c.remotePeer {
+                    self.connectionHistory[pid.b58String, default: []].append( c.stats )
+                }
+            } else {
+                self.logger.error("Failed to remove Connection from list.")
+            }
+            self.connectionStreamCount.removeValue(forKey: id.uuidString)
+        }
+    }
+    
+    private func pruneConenctionHistory(maxEntries:Int) -> EventLoopFuture<Void> {
+        self.eventLoop.submit {
+            if self.connectionHistory.count > maxEntries {
+                (0..<self.connectionHistory.count - maxEntries).forEach { _ in
+                    if let randEntry = self.connectionHistory.randomElement()?.key {
+                        self.connectionHistory.removeValue(forKey: randEntry)
+                    }
+                }
+            }
+        }
+    }
+    
+    private var pruneTask:Scheduled<Void>? = nil
+    private func debouncedPrune() -> EventLoopFuture<Void> {
+        self.eventLoop.flatSubmit {
+            guard self.pruneTask == nil else { /*self.logger.notice("Debouncing Prune");*/ return self.eventLoop.makeSucceededVoidFuture() }
+            self.pruneTask = self.eventLoop.scheduleTask(in: .milliseconds(100), {
+                return self.pruneClosedConnections().flatMap {
+                    self.pruneOldConnections().flatMap {
+                        self.pruneConenctionHistory(maxEntries: 100).map {
+                            self.logger.notice("\(self.connections.count) / \(self.maxPeers) Connections")
+                        }
+                    }
+                }.whenComplete { _ in
+                    self.pruneTask = nil
+                }
+            })
+            return self.pruneTask!.futureResult
+        }
+    }
+    
     func onDisconnectedNew(_ connection:Connection, peer:PeerID?) -> Void {
-        let _ = self.pruneClosedConnections()
-//        let _ = eventLoop.submit {
-//            if let val = self.connections.removeValue(forKey: connection.id.uuidString) {
-//                print("Successfully removed Connection[\(connection.id.uuidString.prefix(5))] from ConnectionManager cache...")
-//            } else {
-//                print("Error::Failed to removed Connection[\(connection.id.uuidString.prefix(5))] from ConnectionManager cache...")
-//            }
-//        }
+        let _ = debouncedPrune()
+    }
+    
+    func onOpenedStream(_ stream:LibP2PCore.Stream) {
+        let _ = self.eventLoop.submit {
+            guard let connection = stream.connection else { self.logger.error("New Stream doesn't have an associated connection"); return }
+            //self.logger.notice("ARC[\(connection.id.uuidString)]::Incrementing Stream Count")
+            self.connectionStreamCount[connection.id.uuidString, default: 0] += 1
+        }
+    }
+    
+    var alerts:[UUID:Date] = [:]
+    let idleTime:Int64 = 1000
+    func onClosedStream(_ stream:LibP2PCore.Stream) {
+        let _ = self.eventLoop.submit {
+            guard let connection = stream.connection else { self.logger.error("New Stream doesn't have an associated connection"); return }
+            guard connection.status != .closed else { return }
+            guard let streamCount = self.connectionStreamCount[connection.id.uuidString] else { self.logger.error("Unbalanced Stream Open/Closed Count"); return }
+            //self.logger.notice("ARC[\(connection.id.uuidString)]::Decrementing Stream Count \(streamCount) - 1")
+            if streamCount == 1 {
+                /// Decrement our stream count
+                self.connectionStreamCount[connection.id.uuidString] = 0
+                self.alerts[connection.id] = Date()
+                /// Wait one second, if it's still at 0 after a second then we assume it's idle / unsused and we proceed to close it...
+                self.eventLoop.scheduleTask(in: .milliseconds(self.idleTime)) {
+                    if let alertEntry = self.alerts.removeValue(forKey: connection.id) {
+                        if Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970 > (Double(self.idleTime) * 0.0015) {
+                            self.logger.error("🚨🚨🚨 ARC Running Slow!!! 🚨🚨🚨")
+                            self.logger.error("\(Double(self.idleTime) / 1000.0) seconds took \(Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970)s")
+                        }
+                    }
+                    if self.connectionStreamCount[connection.id.uuidString] == 0 {
+                        connection.close().whenComplete { _ in self.logger.notice("Closed Connection using Automatic Reference Counting!") }
+                        if let c = self.connections.removeValue(forKey: connection.id.uuidString) {
+                            if let pid = c.remotePeer {
+                                self.connectionHistory[pid.b58String, default: []].append( c.stats )
+                            }
+                        }
+                        self.connectionStreamCount.removeValue(forKey: connection.id.uuidString)
+                    }
+                }
+                
+            } else {
+                self.connectionStreamCount[connection.id.uuidString, default: streamCount] -= 1
+            }
+        }
     }
     
     func dumpConnectionHistory() {
         eventLoop.execute { () in
             self.logger.info("""
             
-            --- Connection History ---
+            --- Connection History <\(self.connectionHistory.count)> ---
             \(self.connectionHistory.map { kv in
                 var str = "Peer: \(kv.key)"
                 str += kv.value.map { $0.description }.joined(separator: "\n")
                 return str
             }.joined(separator: "\n---\n"))
-            --------------------------
+            -----------------------------
             """)
         }
     }

--- a/Sources/LibP2P/Identify/ID/ID_Routes.swift
+++ b/Sources/LibP2P/Identify/ID/ID_Routes.swift
@@ -26,7 +26,7 @@ func routes(_ app: Application) throws {
             
             // Route Endpoint: ipfs/id/1.0.0
             // Handlers: .partialIdentifyMessageHandler used to accumulate partial IdentifyMessages before triggering our handler
-            id.on("1.0.0", handlers: [.partialIdentifyMessageHandler]) { req -> ResponseType<ByteBuffer> in
+            id.on("1.0.0", handlers: [.partialIdentifyMessageHandler]) { req -> Response<ByteBuffer> in
                 return handleIDRequest(req)
             }
             
@@ -34,7 +34,7 @@ func routes(_ app: Application) throws {
             id.group("delta") { delta in
                 
                 // Route Endpoint: ipfs/id/delta/1.0.0
-                delta.on("1.0.0") { req -> ResponseType<ByteBuffer> in
+                delta.on("1.0.0") { req -> Response<ByteBuffer> in
                     return handleDeltaRequest(req)
                 }
             }
@@ -43,7 +43,7 @@ func routes(_ app: Application) throws {
             id.group("push") { push in
                 
                 // Route Endpoint: ipfs/id/push/1.0.0
-                push.on("1.0.0") { req -> ResponseType<ByteBuffer> in
+                push.on("1.0.0") { req -> Response<ByteBuffer> in
                     return handlePushRequest(req)
                 }
             }
@@ -53,7 +53,7 @@ func routes(_ app: Application) throws {
         ipfs.group("ping") { ping in
             
             // Route Enpoint: /ipfs/ping/1.0.0
-            ping.on("1.0.0") { req -> ResponseType<ByteBuffer> in
+            ping.on("1.0.0") { req -> Response<ByteBuffer> in
                 return handlePingRequest(req)
             }
         }

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Toms on 5/1/22.
 //
 
-internal func handleIDRequest(_ req:Request) -> ResponseType<ByteBuffer> {
+internal func handleIDRequest(_ req:Request) -> Response<ByteBuffer> {
     switch req.event {
     case .ready:
         guard req.streamDirection == .inbound else {

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Toms on 5/1/22.
 //
 
-internal func handleDeltaRequest(_ req:Request) -> ResponseType<ByteBuffer> {
+internal func handleDeltaRequest(_ req:Request) -> Response<ByteBuffer> {
     guard req.streamDirection == .inbound else {
         req.logger.error("Identify::Delta::Error - We dont support outbound /ipfs/id/delta messages on this handler")
         return .close
@@ -15,6 +15,9 @@ internal func handleDeltaRequest(_ req:Request) -> ResponseType<ByteBuffer> {
         return .stayOpen
     case .data:
         req.logger.warning("Identify::Delta::We haven't tested this yet!")
+        //req.logger.warning("🚨 Received Delta ID Payload 🚨")
+        //req.logger.warning("\(Data(req.payload.readableBytesView).toHexString())")
+        //req.logger.warning("---------------------")
         handleDeltaMessage(req)
     default:
         break

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
@@ -23,7 +23,7 @@ internal func handlePushRequest(_ req:Request) -> Response<ByteBuffer> {
         
         /// Update values that are present...
         req.logger.warning("Identify::Push::We haven't tested this yet!")
-        manager.consumeIdentifyMessage(payload: Data(payload.readableBytesView), id: req.remotePeer!.b58String, connection: req.connection)
+        manager.consumePushIdentifyMessage(payload: Data(payload.readableBytesView), id: req.remotePeer!.b58String, connection: req.connection)
         return .close
         
     default:

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Toms on 5/1/22.
 //
 
-internal func handlePushRequest(_ req:Request) -> ResponseType<ByteBuffer> {
+internal func handlePushRequest(_ req:Request) -> Response<ByteBuffer> {
     guard req.streamDirection == .inbound else {
         req.logger.error("Identify::Push::Error - We dont support outbound /ipfs/id/push messages on this handler")
         return .close

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_Ping.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_Ping.swift
@@ -5,7 +5,7 @@
 //  Created by Brandon Toms on 5/1/22.
 //
 
-internal func handlePingRequest(_ req:Request) -> ResponseType<ByteBuffer> {
+internal func handlePingRequest(_ req:Request) -> Response<ByteBuffer> {
     switch req.streamDirection {
     case .inbound:
         switch req.event {

--- a/Sources/LibP2P/LibP2P.swift
+++ b/Sources/LibP2P/LibP2P.swift
@@ -30,7 +30,18 @@ public final class Application {
     var isBooted: Bool
     public private(set) var isRunning:Bool = false
     
+    /// The PeerID of our libp2p instance
     public let peerID:PeerID
+    
+    /// The PeerInfo of our libp2p instance
+    ///
+    /// The PeerInfo contains both our PeerID and our Listening Addresses
+    public var peerInfo:PeerInfo {
+        PeerInfo(
+            peer: self.peerID,
+            addresses: self.listenAddresses
+        )
+    }
 
     public struct Lifecycle {
         var handlers: [LifecycleHandler]
@@ -248,6 +259,14 @@ public final class Application {
         if !self.didShutdown {
             assertionFailure("Application.shutdown() was not called before Application deinitialized.")
         }
+    }
+    
+    public enum Errors:Error {
+        case noTransportForMultiaddr(Multiaddr)
+        case unknownConnection
+        case unknownPeer
+        case noKnownAddressesForPeer
+        case noAddressForDevice
     }
 }
 

--- a/Sources/LibP2P/Middleware/Middleware.swift
+++ b/Sources/LibP2P/Middleware/Middleware.swift
@@ -10,14 +10,14 @@ import NIO
 /// `Middleware` is placed between the server and your router. It is capable of
 /// mutating both incoming requests and outgoing responses. `Middleware` can choose
 /// to pass requests on to the next `Middleware` in a chain, or they can short circuit and
-/// return a custom `Response` if desired.
+/// return a custom `RawResponse` if desired.
 public protocol Middleware {
     /// Called with each `Request` that passes through this middleware.
     /// - parameters:
     ///     - request: The incoming `Request`.
     ///     - next: Next `Responder` in the chain, potentially another middleware or the main router.
-    /// - returns: An asynchronous `Response`.
-    func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response>
+    /// - returns: An asynchronous `RawResponse`.
+    func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<RawResponse>
 }
 
 extension Array where Element == Middleware {
@@ -48,7 +48,7 @@ private struct BasicMiddlewareResponder: Responder {
         self.responder = responder
     }
     
-    func respond(to request: Request) -> EventLoopFuture<Response> {
+    func respond(to request: Request) -> EventLoopFuture<RawResponse> {
         return self.middleware.respond(to: request, chainingTo: self.responder)
     }
     

--- a/Sources/LibP2P/Responder/Application+Responder.swift
+++ b/Sources/LibP2P/Responder/Application+Responder.swift
@@ -9,7 +9,7 @@ import NIO
 import LibP2PCore
 
 public protocol Responder {
-    func respond(to request: Request) -> EventLoopFuture<Response>
+    func respond(to request: Request) -> EventLoopFuture<RawResponse>
     func pipelineConfig(for protocol: String, on:Connection) -> [ChannelHandler]?
 }
 
@@ -80,7 +80,7 @@ extension Application {
 }
 
 extension Application.Responder: Responder {
-    public func respond(to request: Request) -> EventLoopFuture<Response> {
+    public func respond(to request: Request) -> EventLoopFuture<RawResponse> {
         self.current.respond(to: request)
     }
     

--- a/Sources/LibP2P/Responder/BasicResponder.swift
+++ b/Sources/LibP2P/Responder/BasicResponder.swift
@@ -10,7 +10,7 @@ import NIO
 /// A basic, closure-based `Responder`.
 public struct BasicResponder: Responder {
     /// The stored responder closure.
-    private let closure: (Request) throws -> EventLoopFuture<Response>
+    private let closure: (Request) throws -> EventLoopFuture<RawResponse>
 
     /// The ChannelHandlers that should be installed on the ChildChannel Pipeline
     private let handlers:[ChannelHandler]
@@ -27,7 +27,7 @@ public struct BasicResponder: Responder {
     /// - parameters:
     ///     - closure: Responder closure.
     public init(
-        closure: @escaping (Request) throws -> EventLoopFuture<Response>,
+        closure: @escaping (Request) throws -> EventLoopFuture<RawResponse>,
         handlers: [ChannelHandler] = []
 //        file: String = #file, function: String = #function, line: Int = #line
     ) {
@@ -42,7 +42,7 @@ public struct BasicResponder: Responder {
 //    }
 
     /// See `Responder`.
-    public func respond(to request: Request) -> EventLoopFuture<Response> {
+    public func respond(to request: Request) -> EventLoopFuture<RawResponse> {
 //        didRespond = true
         do {
             return try closure(request)

--- a/Sources/LibP2P/Responder/DefaultResponder.swift
+++ b/Sources/LibP2P/Responder/DefaultResponder.swift
@@ -58,9 +58,9 @@ internal struct DefaultResponder: Responder {
     }
 
     /// See `Responder`
-    public func respond(to request: Request) -> EventLoopFuture<Response> {
+    public func respond(to request: Request) -> EventLoopFuture<RawResponse> {
         let startTime = DispatchTime.now().uptimeNanoseconds
-        let response: EventLoopFuture<Response>
+        let response: EventLoopFuture<RawResponse>
         if let cachedRoute = self.getRoute(for: request) {
             request.route = cachedRoute.route
             response = cachedRoute.responder.respond(to: request)
@@ -185,7 +185,7 @@ public extension Multiaddr {
 }
 
 private struct NotFoundResponder: Responder {
-    func respond(to request: Request) -> EventLoopFuture<Response> {
+    func respond(to request: Request) -> EventLoopFuture<RawResponse> {
         request.eventLoop.makeFailedFuture(RouteNotFound())
     }
     

--- a/Sources/LibP2P/Response/ResponseCodable.swift
+++ b/Sources/LibP2P/Response/ResponseCodable.swift
@@ -7,16 +7,16 @@
 
 import NIO
 
-/// Can convert `self` to a `Response`.
+/// Can convert `self` to a `RawResponse`.
 ///
 /// Types that conform to this protocol can be returned in route closures.
 public protocol ResponseEncodable {
-    /// Encodes an instance of `Self` to a `Response`.
+    /// Encodes an instance of `Self` to a `RawResponse`.
     ///
     /// - parameters:
-    ///     - for: The `Request` associated with this `Response`.
-    /// - returns: A `Response`.
-    func encodeResponse(for request: Request) -> EventLoopFuture<Response>
+    ///     - for: The `Request` associated with this `RawResponse`.
+    /// - returns: A `RawResponse`.
+    func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse>
 }
 
 /// Can convert `Request` to a `Self`.
@@ -38,61 +38,61 @@ extension Request: RequestDecodable {
 }
 
 // MARK: Default Conformances
-extension Response: ResponseEncodable {
+extension RawResponse: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         return request.eventLoop.makeSucceededFuture(self)
     }
 }
 
 extension StaticString: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         //let res = Response(payload: .init(staticString: self))
-        let res = Response(payload: request.allocator.buffer(staticString: self))
+        let res = RawResponse(payload: request.allocator.buffer(staticString: self))
         return request.eventLoop.makeSucceededFuture(res)
     }
 }
 
 extension String: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         //let res = Response(payload: .init(string: self))
-        let res = Response(payload: request.allocator.buffer(string: self))
+        let res = RawResponse(payload: request.allocator.buffer(string: self))
         return request.eventLoop.makeSucceededFuture(res)
     }
 }
 
 extension ByteBuffer: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         //let res = Response(payload: .init(buffer: self))
-        let res = Response(payload: request.allocator.buffer(buffer: self))
+        let res = RawResponse(payload: request.allocator.buffer(buffer: self))
         return request.eventLoop.makeSucceededFuture(res)
     }
 }
 
 extension Data: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         //let res = Response(payload: .init(bytes: self.bytes))
-        let res = Response(payload: request.allocator.buffer(bytes: self.bytes))
+        let res = RawResponse(payload: request.allocator.buffer(bytes: self.bytes))
         return request.eventLoop.makeSucceededFuture(res)
     }
 }
 
 extension Array: ResponseEncodable where Element == UInt8 {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         //let res = Response(payload: .init(bytes: self))
-        let res = Response(payload: request.allocator.buffer(bytes: self))
+        let res = RawResponse(payload: request.allocator.buffer(bytes: self))
         return request.eventLoop.makeSucceededFuture(res)
     }
 }
 
 extension EventLoopFuture: ResponseEncodable where Value: ResponseEncodable {
     // See `ResponseEncodable`.
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request) -> EventLoopFuture<RawResponse> {
         return self.flatMap { t in
             return t.encodeResponse(for: request)
         }

--- a/Sources/LibP2P/Response/ResponseDecoderChannelHandler.swift
+++ b/Sources/LibP2P/Response/ResponseDecoderChannelHandler.swift
@@ -8,7 +8,7 @@
 import NIO
 
 final class ResponseDecoderChannelHandler: ChannelOutboundHandler, RemovableChannelHandler {
-    typealias OutboundIn = Response
+    typealias OutboundIn = RawResponse
     typealias OutboundOut = ByteBuffer
     
     private let logger:Logger

--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -17,9 +17,21 @@ extension Application {
         self.servers.use(serverProvider)
     }
     
+//    public var listenAddresses:[Multiaddr] {
+//        self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
+//            partialResult.append(server.listeningAddress)
+//        }
+//    }
+    
     public var listenAddresses:[Multiaddr] {
-        self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
+        return self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
             partialResult.append(server.listeningAddress)
+        }.map { ma in
+            if let tcp = ma.tcpAddress, tcp.address == "0.0.0.0", let en0 = (try? self.getSystemAddress(forDevice: "en0"))?.address?.ipAddress {
+                return (try? ma.swap(address: en0, forCodec: .ip4)) ?? ma
+            } else {
+                return ma
+            }
         }
     }
 

--- a/Sources/LibP2P/Transports/TCP/Client/TCPClient.swift
+++ b/Sources/LibP2P/Transports/TCP/Client/TCPClient.swift
@@ -48,9 +48,9 @@ public struct TCPClient:Client {
     }
     
     public func execute(request: ClientRequest, eventLoop: EventLoop, logger: Logger?) -> EventLoopFuture<ClientResponse> {
-        guard let tcpAddress = request.addr.tcpAddress else {
-            return eventLoop.makeFailedFuture(Errors.invalidMultiaddrForTransport)
-        }
+//        guard let tcpAddress = request.addr.tcpAddress else {
+//            return eventLoop.makeFailedFuture(Errors.invalidMultiaddrForTransport)
+//        }
 //        client.connect(host: tcpAddress.address, port: tcpAddress.port).flatMap { channel -> EventLoopFuture<Connection> in
 //
 //            let conn = BasicConnectionLight(

--- a/Sources/LibP2P/Transports/TCP/LibP2PTCP.swift
+++ b/Sources/LibP2P/Transports/TCP/LibP2PTCP.swift
@@ -74,7 +74,7 @@ public struct TCP: Transport {
         return sharedClient.connect(host: tcp.address, port: tcp.port).flatMap { channel -> EventLoopFuture<Connection> in
             
             self.application.logger.trace("Instantiating new BasicConnectionLight")
-            let conn = BasicConnectionLight(application: application, channel: channel, direction: .outbound, remoteAddress: address, expectedRemotePeer: try? PeerID(cid: address.getPeerID() ?? ""))
+            let conn = application.connectionManager.generateConnection(channel: channel, direction: .outbound, remoteAddress: address, expectedRemotePeer: try? PeerID(cid: address.getPeerID() ?? ""))
             
             /// The connection installs the necessary channel handlers here
             self.application.logger.trace("Asking BasicConnectionLight to instantiate new outbound channel")
@@ -121,6 +121,7 @@ public struct TCP: Transport {
     public enum Errors:Error {
         case notYetImplemeted
         case invalidMultiaddr
+        case inboundConnectionAfterApplicationShutdown
     }
 }
 

--- a/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
+++ b/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
@@ -268,21 +268,17 @@ private final class TCPServerConnection {
             
             // Set the handlers that are applied to the accepted Channels
             .childChannelInitializer { [weak application] channel in
-                let conn = BasicConnectionLight(application: application!, channel: channel, direction: .inbound, remoteAddress: try! channel.remoteAddress!.toMultiaddr(), expectedRemotePeer: nil)
+                guard let application = application else { return channel.eventLoop.makeFailedFuture(TCP.Errors.inboundConnectionAfterApplicationShutdown) }
+                guard let remoteAddress = try? channel.remoteAddress?.toMultiaddr() else { return channel.eventLoop.makeFailedFuture(TCP.Errors.invalidMultiaddr) } //.always({ _ in channel.close(mode: .all) }) }
+                let conn = application.connectionManager.generateConnection(channel: channel, direction: .inbound, remoteAddress: remoteAddress, expectedRemotePeer: nil)
                 
-                /// Add the new inbound conneciton to our ConnectionManager
-                return application!.connections.addConnection(conn, on: nil).flatMap {
+                // Add the new inbound connection to our ConnectionManager
+                return application.connections.addConnection(conn, on: nil).flatMap {
                     channel.pipeline.addHandler(BackPressureHandler(), position: .first).flatMap {
-                        /// Initialize the new inbound channel
+                        // Initialize the new inbound channel
                         conn.initializeChannel()
                     }
                 }
-                
-//                return channel.pipeline.addTCPHandlers(
-//                    application: application!,
-//                    responder: responder,
-//                    configuration: configuration
-//                )
             }
             
             // Enable TCP_NODELAY and SO_REUSEADDR for the accepted Channels
@@ -347,14 +343,3 @@ final class TCPServerErrorHandler: ChannelInboundHandler {
         context.close(mode: .output, promise: nil)
     }
 }
-
-//extension ChannelPipeline {
-//    func addTCPHandlers(
-//        application: Application,
-//        responder: Responder,
-//        configuration: TCPServer.Configuration
-//    ) -> EventLoopFuture<Void> {
-//        var handlers: [ChannelHandler] = []
-//      ...
-//    }
-//}

--- a/Sources/LibP2P/Utilities/SystemAddresses+Application.swift
+++ b/Sources/LibP2P/Utilities/SystemAddresses+Application.swift
@@ -1,0 +1,20 @@
+//
+//  SystemAddresses+Application.swift
+//  
+//
+//  Created by Brandon Toms on 10/21/22.
+//
+
+extension Application {
+    /// This method attempts to find a System Address fro the provided device name (defaults to device 'en0')
+    func getSystemAddress(forDevice name: String = "en0") throws -> NIONetworkDevice {
+        let devices = try System.enumerateDevices().filter({ device in
+            guard device.name == name && device.address != nil else { return false }
+            guard let ma = try? device.address?.toMultiaddr().tcpAddress else { return false }
+            
+            return ma.ip4
+        })
+        guard let device = devices.first else { throw Errors.noAddressForDevice }
+        return device
+    }
+}


### PR DESCRIPTION
This PR introduces...
- A new `Connection` implementation (`ARCConnection`)
   - `ARCConnection`s are an attempt at creating a `Connection` that closes itself after a given idle time
   - Idle being 0 active `Stream`s open within the idle grace period (250ms to start)
- An updated `ConnectionManager`
   - Ability to force close / prune active connections when we're at our max connection limit.
   - Implemented a buffer zone where outgoing connections are allowed while incoming connections aren't
   - Better connection history logging
- An updated `PeerStore`
   - Ability to prune peers once we reach the maximum peer amount
   - Ability to compact peerstore records
- API Change from `ResponseType` to `Response`
``` swift
/// OLD
host.routes.on("echo", "1.0.0") { req -> ResponseType<ByteBuffer> in ... }

/// NEW
host.routes.on("echo", "1.0.0") { req -> Response<ByteBuffer> in ... }
```
- `Identify Protocol` Improvements
- General bug fixes
