### PR TITLE
Fixing Connection Retain Cycle

### DIFF
--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -85,5 +85,19 @@ extension Application {
         public func setIdleTimeout(_ timeout:TimeAmount) {
             self.storage.manager?.setIdleTimeout(timeout)
         }
+        
+        public func getTotalConnectionCount() -> EventLoopFuture<UInt64> {
+            if let basicMan = self.storage.manager as? BasicInMemoryConnectionManager {
+                return basicMan.getTotalConnectionCount()
+            }
+            return self.application.eventLoopGroup.next().makeFailedFuture(Errors.notImplementedYet)
+        }
+        
+        public func getTotalStreamCount() -> EventLoopFuture<UInt64> {
+            if let basicMan = self.storage.manager as? BasicInMemoryConnectionManager {
+                return basicMan.getTotalStreamCount()
+            }
+            return self.application.eventLoopGroup.next().makeFailedFuture(Errors.notImplementedYet)
+        }
     }
 }

--- a/Sources/LibP2P/LibP2P.swift
+++ b/Sources/LibP2P/LibP2P.swift
@@ -95,7 +95,7 @@ public final class Application {
         _ environment: Environment = .development,
         peerID:PeerID = try! PeerID(.Ed25519),
         maxConncurrentConnections:Int = 50,
-        enableAutomaticStreamCounting:Bool = true,
+        enableAutomaticStreamCounting:Bool = false,
         eventLoopGroupProvider: EventLoopGroupProvider = .createNew
     ) {
         /// Create our PeerID for this application instance

--- a/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
+++ b/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
@@ -49,6 +49,7 @@ internal final class BasicInMemoryPeerStore:PeerStore {
     private var logger:Logger
     
     private var maxPeers:Int = 5000
+    private var maxRecordsPerPeer:Int = 3
     private var isPruning:Bool = false
     
     /// - Note: Should the peerstore be responsible for emiting certain events?
@@ -434,6 +435,9 @@ internal final class BasicInMemoryPeerStore:PeerStore {
             if !compPeer.records.contains(where: { $0.sequenceNumber == record.sequenceNumber }) {
                 compPeer.records.append(record)
             } else { self.logger.debug("PeerStore::Skipping Duplicate PeerRecord Entry - Sequence Number: \(record.sequenceNumber)") }
+            if compPeer.records.count > self.maxRecordsPerPeer {
+                compPeer.records = Array(compPeer.records.sorted(by: {$0.sequenceNumber > $1.sequenceNumber}).prefix(self.maxRecordsPerPeer))
+            }
         }.hop(to: on ?? eventLoop)
     }
     


### PR DESCRIPTION
This PR along with https://github.com/swift-libp2p/swift-libp2p-mplex/pull/3 helps ensure `Connection`s are deallocated appropriately. 

We had a retain cycle between the MPLEX Muxer and its underlying `Connection` via the `inboundStreamStateInitializer` and the `onStream` and `onStreamEnd` callbacks we introduced. These are all explicitly nilled out upon closing the `Connection`. 

> **Note**
> This breaks the Automatic Stream Reference Counting feature we were testing in our ConnectionManager due to the Connection associated with the Stream object being nil by the time we receive the onStreamClosed event... Therefore ASRC has been disabled by default until we come up with a cleaner solution.