### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,11 +43,11 @@ let package = Package(
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0"),
         // LibP2P Core
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.3.0")),
         // Multiaddr
-        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.1.0")),
         // LibP2P Peer Identities
-        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMajor(from: "0.0.1")),
+        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMinor(from: "0.1.0")),
         // Sugary extensions for the SwiftNIO library
         .package(url: "https://github.com/vapor/async-kit.git", .exact("1.11.1")),
         // Swift Protobuf

--- a/Sources/LibP2P/Clients/Client+Utils.swift
+++ b/Sources/LibP2P/Clients/Client+Utils.swift
@@ -261,8 +261,7 @@ extension Application {
                 // We resolved an address...
                 // Instead of trying any random multiaddr, lets see if we have a PeerID we can use to find existing connections...
                 if let peer = resolvedAddresses.compactMap({ ma -> PeerID? in
-                    guard let cid = ma.getPeerID() else { return nil }
-                    return try? PeerID(cid: cid)
+                    try? ma.getPeerID()
                 }).first {
                     return self.connections.getBestConnectionForPeer(peer: peer, on: loop).flatMap {
                         conn -> EventLoopFuture<Multiaddr> in

--- a/Sources/LibP2P/Discovery/Bootstrap/Application+Bootstrap.swift
+++ b/Sources/LibP2P/Discovery/Bootstrap/Application+Bootstrap.swift
@@ -42,8 +42,7 @@ extension Application.DiscoveryServices.Provider {
                     on: app.eventLoopGroup.next(),
                     withPeers: peers.compactMap {
                         guard let ma = try? Multiaddr($0) else { return nil }
-                        guard let cid = ma.getPeerID() else { return nil }
-                        guard let pid = try? PeerID(cid: cid) else { return nil }
+                        guard let pid = try? ma.getPeerID() else { return nil }
                         return PeerInfo(peer: pid, addresses: [ma])
                     }
                 )
@@ -60,8 +59,7 @@ extension Application.DiscoveryServices.Provider {
                 let boot = BootstrapPeerDiscovery(
                     on: app.eventLoopGroup.next(),
                     withPeers: peers.compactMap {
-                        guard let cid = $0.getPeerID() else { return nil }
-                        guard let pid = try? PeerID(cid: cid) else { return nil }
+                        guard let pid = try? $0.getPeerID() else { return nil }
                         return PeerInfo(peer: pid, addresses: [$0])
                     }
                 )

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -391,7 +391,7 @@ extension Identify {
     // - TODO:  This doesn't handle multiple parallel outbound pings to the same peer
     func initiateOutboundPingTo(addr: Multiaddr) -> EventLoopFuture<TimeAmount> {
         self.el.flatSubmit {
-            guard let cid = addr.getPeerID(), let peer = try? PeerID(cid: cid) else {
+            guard let peer = try? addr.getPeerID() else {
                 self.logger.warning("Identify::Failed to ping addr `\(addr)`. A valid peerID is neccessary")
                 return self.el.makeFailedFuture(Errors.timedOut)
             }

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -365,7 +365,7 @@ extension Identify {
     // - TODO:  This doesn't handle multiple parallel outbound pings to the same peer
     func initiateOutboundPingTo(peer: PeerID) -> EventLoopFuture<TimeAmount> {
         self.el.flatSubmit {
-            if let outstandingPing = self.pingCache[peer.bytes] {
+            if let outstandingPing = self.pingCache[peer.id] {
                 // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
                 if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
                     print("We have an outstanding ping thats older than 3 seconds")
@@ -374,11 +374,11 @@ extension Identify {
                     // If the outstanding ping hasn't timed out yet, just return the results of the existing promise
                     return promise.futureResult
                 }
-                self.pingCache.removeValue(forKey: peer.bytes)
+                self.pingCache.removeValue(forKey: peer.id)
             }
             //guard self.pingCache[peer.bytes] == nil else { return application!.eventLoopGroup.next().makeFailedFuture(Errors.timedOut) }
             let promise = self.application!.eventLoopGroup.next().makePromise(of: TimeAmount.self)
-            self.pingCache[peer.bytes] = PendingPing(
+            self.pingCache[peer.id] = PendingPing(
                 peer: "",
                 startTime: DispatchTime.now().uptimeNanoseconds,
                 promise: promise
@@ -395,7 +395,7 @@ extension Identify {
                 self.logger.warning("Identify::Failed to ping addr `\(addr)`. A valid peerID is neccessary")
                 return self.el.makeFailedFuture(Errors.timedOut)
             }
-            if let outstandingPing = self.pingCache[peer.bytes] {
+            if let outstandingPing = self.pingCache[peer.id] {
                 // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
                 if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
                     print("We have an outstanding ping thats older than 3 seconds")
@@ -404,11 +404,11 @@ extension Identify {
                     // If the outstanding ping hasn't timed out yet, just return the results of the existing promise
                     return promise.futureResult
                 }
-                self.pingCache.removeValue(forKey: peer.bytes)
+                self.pingCache.removeValue(forKey: peer.id)
             }
             //guard self.pingCache[peer.bytes] == nil else { return application!.eventLoopGroup.next().makeFailedFuture(Errors.timedOut) }
             let promise = self.application!.eventLoopGroup.next().makePromise(of: TimeAmount.self)
-            self.pingCache[peer.bytes] = PendingPing(
+            self.pingCache[peer.id] = PendingPing(
                 peer: "",
                 startTime: DispatchTime.now().uptimeNanoseconds,
                 promise: promise
@@ -428,7 +428,7 @@ extension Identify {
         let startTime = DispatchTime.now().uptimeNanoseconds
         /// Check to see if this ping was initiated by our IndetifyManager...
         self.el.execute {
-            if let initiatedPing = self.pingCache.removeValue(forKey: remotePeer.bytes) {
+            if let initiatedPing = self.pingCache.removeValue(forKey: remotePeer.id) {
                 self.pingCache[bytes] = PendingPing(
                     peer: remotePeer.b58String,
                     startTime: startTime,

--- a/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
+++ b/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
@@ -273,7 +273,7 @@ internal final class BasicInMemoryPeerStore: PeerStore {
     /// Adds a Multiaddr to an existing PeerID
     func add(address: Multiaddr, toPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<Void> {
         getPeer(withID: peer.b58String).map { compPeer in
-            if let pid = address.getPeerID() { guard pid == peer.b58String else { return } }
+            if let pid = try? address.getPeerID() { guard pid == peer else { return } }
             if !compPeer.addresses.contains(address) { compPeer.addresses.append(address) }
         }.hop(to: on ?? eventLoop)
     }
@@ -282,7 +282,7 @@ internal final class BasicInMemoryPeerStore: PeerStore {
         guard !addresses.isEmpty else { return on?.makeSucceededVoidFuture() ?? eventLoop.makeSucceededVoidFuture() }
         return getPeer(withID: peer.b58String).map { compPeer in
             for address in addresses {
-                if let pid = address.getPeerID() { guard pid == peer.b58String else { return } }
+                if let pid = try? address.getPeerID() { guard pid == peer else { return } }
                 if !compPeer.addresses.contains(address) { compPeer.addresses.append(address) }
             }
         }.hop(to: on ?? eventLoop)

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -145,7 +145,7 @@ extension Application {
         let el = self.eventLoopGroup.next()
 
         /// Search by PeerID if possible...
-        if let cid = multiaddr.getPeerID(), let pid = try? PeerID(cid: cid) {
+        if let pid = try? multiaddr.getPeerID() {
             return self.peers.getAddresses(forPeer: pid, on: el).flatMapAlways {
                 result -> EventLoopFuture<[Multiaddr]> in
                 switch result {

--- a/Sources/LibP2P/Transports/TCP/LibP2PTCP.swift
+++ b/Sources/LibP2P/Transports/TCP/LibP2PTCP.swift
@@ -86,7 +86,7 @@ public struct TCP: Transport {
                 channel: channel,
                 direction: .outbound,
                 remoteAddress: address,
-                expectedRemotePeer: try? PeerID(cid: address.getPeerID() ?? "")
+                expectedRemotePeer: try? address.getPeerID()
             )
 
             /// The connection installs the necessary channel handlers here


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```