### PR TITLE
PeerStore Application Visibility

### DIFF
--- a/Sources/LibP2P/Peerstore/Application+PeerStore.swift
+++ b/Sources/LibP2P/Peerstore/Application+PeerStore.swift
@@ -60,7 +60,7 @@ extension Application {
             self.storage.manager.withLockedValue { $0 = makeManager(self.application) }
         }
 
-        let application: Application
+        public let application: Application
 
         var storage: Storage {
             guard let storage = self.application.storage[Key.self] else {


### PR DESCRIPTION
### What?
Changed `PeerStores` `application` visibility to `public` so external `PeerStore` `providers` can access it