### PR TITLE
Fix: Defensive guards for post-shutdown property access

### DIFF
--- a/Sources/LibP2P/Cache/Application+Cache.swift
+++ b/Sources/LibP2P/Cache/Application+Cache.swift
@@ -74,6 +74,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Same teardown-race shape as `Application+Identify`,
+                // `Application+EventBus`, etc. The Cache subsystem
+                // is not on libp2p's stream-handling hot path, but
+                // mirroring the guard here keeps the fork uniform.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Caches not configured. Configure with app.caches.initialize()")
             }

--- a/Sources/LibP2P/Clients/Application+Clients.swift
+++ b/Sources/LibP2P/Clients/Application+Clients.swift
@@ -80,6 +80,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Clients not initialized. Initialize with app.clients.initialize()")
             }

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -84,6 +84,13 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("ConnectionManager not initialized. Configure with app.connectionManager.initialize()")
             }

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -24,10 +24,18 @@ extension Application {
 
     public var connections: ConnectionManager {
         let manager = self.connectionManager.storage.manager.withLockedValue { $0 }
-        guard let manager else {
-            fatalError("No ConnectionManager configured. Configure with app.connectionManager.use(...)")
+        if let manager { return manager }
+        if self.isShuttingDown {
+            // Race window: Application has begun teardown so the
+            // post-shutdown `storage` getter returned an empty
+            // `Storage` whose `manager` is `nil`. Hand back a
+            // fresh `BasicInMemoryConnectionManager` — operations
+            // on this throwaway instance are vacuous (no
+            // connections registered) and any callers racing the
+            // teardown complete without crashing.
+            return BasicInMemoryConnectionManager(application: self)
         }
-        return manager
+        fatalError("No ConnectionManager configured. Configure with app.connectionManager.use(...)")
     }
 
     public struct Connections: Sendable {

--- a/Sources/LibP2P/Core/Core.swift
+++ b/Sources/LibP2P/Core/Core.swift
@@ -159,6 +159,21 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                //
+                // Confirmed 2026-05-19: under serial `swift test`
+                // runs of BurrowsNet (Phase 8.4 CI), the previous
+                // suite's in-flight YAMUX streams can deliver to a
+                // stack whose Core storage has already been cleared,
+                // hitting this path during the next suite's setUp.
+                // Same guard pattern as `Application+Clients`,
+                // `Application+Identify`, `Application+Topology`.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Core not configured. Configure with app.core.initialize()")
             }

--- a/Sources/LibP2P/Core/Core.swift
+++ b/Sources/LibP2P/Core/Core.swift
@@ -164,14 +164,6 @@ extension Application {
                 // Returning a fresh empty `Storage` lets stranded
                 // event-loop callbacks finish vacuously instead of
                 // trapping at the `fatalError` below.
-                //
-                // Confirmed 2026-05-19: under serial `swift test`
-                // runs of BurrowsNet (Phase 8.4 CI), the previous
-                // suite's in-flight YAMUX streams can deliver to a
-                // stack whose Core storage has already been cleared,
-                // hitting this path during the next suite's setUp.
-                // Same guard pattern as `Application+Clients`,
-                // `Application+Identify`, `Application+Topology`.
                 return Storage()
             }
             guard let storage = self.application.storage[Key.self] else {

--- a/Sources/LibP2P/DHT/Application+DHT.swift
+++ b/Sources/LibP2P/DHT/Application+DHT.swift
@@ -74,6 +74,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("DHT Service Storage not initialized. Initialize with app.dht.initialize()")
             }

--- a/Sources/LibP2P/Discovery/Application+Discovery.swift
+++ b/Sources/LibP2P/Discovery/Application+Discovery.swift
@@ -87,6 +87,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Discovery Services not initialized. Initialize with app.discovery.initialize()")
             }

--- a/Sources/LibP2P/EventBus/Application+EventBus.swift
+++ b/Sources/LibP2P/EventBus/Application+EventBus.swift
@@ -21,10 +21,18 @@ extension Application {
 
     public var events: EventBus {
         let eventBus = self.eventbus.storage.eventBus.withLockedValue { $0 }
-        guard let eventBus else {
-            fatalError("No EventBus configured. Configure with app.eventbus.use(...)")
+        if let eventBus { return eventBus }
+        if self.isShuttingDown {
+            // Race window: Application has begun teardown so the
+            // post-shutdown `storage` getter returned an empty
+            // `Storage` whose `eventBus` is `nil`. Hand back a
+            // fresh `EventBus` — its `post(_:)` already guards on
+            // `application.isRunning`, so events get dropped
+            // silently and `on(_:event:)` registrations are
+            // harmless on an app that will never dispatch again.
+            return EventBus(application: self)
         }
-        return eventBus
+        fatalError("No EventBus configured. Configure with app.eventbus.use(...)")
     }
 
     public struct Events: Sendable {
@@ -62,6 +70,13 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("EventBus not initialized. Configure with app.eventbus.initialize()")
             }

--- a/Sources/LibP2P/Identify/Application+Identify.swift
+++ b/Sources/LibP2P/Identify/Application+Identify.swift
@@ -63,6 +63,13 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("IdentityManager not initialized. Configure with app.identityManager.initialize()")
             }

--- a/Sources/LibP2P/Identify/Application+Identify.swift
+++ b/Sources/LibP2P/Identify/Application+Identify.swift
@@ -22,10 +22,17 @@ extension Application {
 
     public var identify: IdentityManager {
         let manager = self.identityManager.storage.manager.withLockedValue { $0 }
-        guard let manager else {
-            fatalError("No IdentityManager configured. Configure with app.identityManager.use(...)")
+        if let manager { return manager }
+        if self.isShuttingDown {
+            // Race window: see `app.events` / `app.connections` for
+            // the matching guards. Hand back a fresh `LibP2P.Identify`
+            // (the top-level default IdentityManager class — disam-
+            // biguated from the `Application.Identify` namespace
+            // struct above) so stranded callbacks complete vacuously
+            // instead of trapping.
+            return LibP2P.Identify(application: self)
         }
-        return manager
+        fatalError("No IdentityManager configured. Configure with app.identityManager.use(...)")
     }
 
     public struct Identify: Sendable {

--- a/Sources/LibP2P/LibP2P.swift
+++ b/Sources/LibP2P/LibP2P.swift
@@ -56,6 +56,24 @@ public final class Application: Sendable {
         self._didShutdown.withLockedValue { $0 }
     }
 
+    /// `true` once ``shutdown()`` or ``asyncShutdown()`` has begun
+    /// dismantling this Application — flipped *before* any storage
+    /// is cleared, providers torn down, or event loops drained.
+    /// Stays `true` until the Application is deallocated. Distinct
+    /// from ``didShutdown``, which only flips once shutdown has
+    /// fully completed.
+    ///
+    /// The race this guards: an event-loop task queued before
+    /// shutdown began but executed after `storage.clear()` would
+    /// otherwise hit `fatalError("X not initialized")` inside the
+    /// post-shutdown storage accessors (Transports, EventBus,
+    /// ConnectionManager, …). Those accessors check this flag and
+    /// return an empty sentinel instead of crashing, so the
+    /// stranded callback completes vacuously.
+    public var isShuttingDown: Bool {
+        self._isShuttingDown.withLockedValue { $0 }
+    }
+
     public var logger: Logger {
         get {
             self._logger.withLockedValue { $0 }
@@ -144,6 +162,7 @@ public final class Application: Sendable {
     private let _environment: NIOLockedValueBox<Environment>
     private let _storage: NIOLockedValueBox<Storage>
     private let _didShutdown: NIOLockedValueBox<Bool>
+    private let _isShuttingDown: NIOLockedValueBox<Bool>
     private let _logger: NIOLockedValueBox<Logger>
     private let _traceAutoPropagation: NIOLockedValueBox<Bool>
     private let _lifecycle: NIOLockedValueBox<Lifecycle>
@@ -251,6 +270,7 @@ public final class Application: Sendable {
         }
         self._locks = .init(.init())
         self._didShutdown = .init(false)
+        self._isShuttingDown = .init(false)
         self._isRunning = .init(false)
 
         let logger = logger ?? .init(label: "libp2p.application[\(peerID.shortDescription)]")
@@ -442,6 +462,13 @@ public final class Application: Sendable {
     )
     public func shutdown() {
         assert(!self.didShutdown, "Application has already shut down")
+        // Flip `isShuttingDown` *before* touching any storage so
+        // stranded event-loop callbacks fall through the defensive
+        // checks in the post-shutdown storage accessors instead of
+        // tripping `fatalError("X not initialized")`. Set early and
+        // never cleared — distinct from `didShutdown`, which only
+        // flips once shutdown has fully completed.
+        self._isShuttingDown.withLockedValue { $0 = true }
         self.logger.debug("Application shutting down")
         self._isRunning.withLockedValue { $0 = false }
 
@@ -479,6 +506,8 @@ public final class Application: Sendable {
 
     public func asyncShutdown() async throws {
         assert(!self.didShutdown, "Application has already shut down")
+        // See the matching block in the sync `shutdown()` above.
+        self._isShuttingDown.withLockedValue { $0 = true }
         self.logger.debug("Application shutting down")
 
         self.logger.trace("Shutting down providers")

--- a/Sources/LibP2P/Muxer/Muxer.swift
+++ b/Sources/LibP2P/Muxer/Muxer.swift
@@ -124,6 +124,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Muxer Upgraders not initialized. Initialize with app.muxers.initialize()")
             }

--- a/Sources/LibP2P/Peerstore/Application+PeerStore.swift
+++ b/Sources/LibP2P/Peerstore/Application+PeerStore.swift
@@ -63,6 +63,13 @@ extension Application {
         public let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Peerstore not initialized. Configure with app.peerstore.initialize()")
             }

--- a/Sources/LibP2P/Peerstore/Application+PeerStore.swift
+++ b/Sources/LibP2P/Peerstore/Application+PeerStore.swift
@@ -22,10 +22,17 @@ extension Application {
 
     public var peers: PeerStore {
         let manager = self.peerstore.storage.manager.withLockedValue { $0 }
-        guard let manager else {
-            fatalError("No Peerstore configured. Configure with app.peerstore.use(...)")
+        if let manager { return manager }
+        if self.isShuttingDown {
+            // Race window: see `app.events` / `app.connections` /
+            // `app.identify` for matching guards. Hand back a fresh
+            // `BasicInMemoryPeerStore` (the default Peerstore impl
+            // — file `DefaultPeerstore.swift` but the type itself is
+            // named `BasicInMemoryPeerStore`) so stranded callbacks
+            // complete vacuously instead of trapping.
+            return BasicInMemoryPeerStore(application: self)
         }
-        return manager
+        fatalError("No Peerstore configured. Configure with app.peerstore.use(...)")
     }
 
     public struct PeerStores: Sendable {

--- a/Sources/LibP2P/PubSub/Application+PubSub.swift
+++ b/Sources/LibP2P/PubSub/Application+PubSub.swift
@@ -76,6 +76,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("PubSub Service Storage not initialized. Initialize with app.pubsub.initialize()")
             }

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -213,6 +213,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Resolver not initialized. Configure with app.resolver.initialize()")
             }

--- a/Sources/LibP2P/Responder/Application+Responder.swift
+++ b/Sources/LibP2P/Responder/Application+Responder.swift
@@ -62,10 +62,18 @@ extension Application {
         public let application: Application
 
         public var current: LibP2P.Responder {
-            guard let factory = self.storage.factory.withLockedValue({ $0.factory }) else {
-                fatalError("No responder configured. Configure with app.responder.use(...)")
+            if let factory = self.storage.factory.withLockedValue({ $0.factory }) {
+                return factory(self.application)
             }
-            return factory(self.application)
+            if self.application.isShuttingDown {
+                // Stranded inbound stream reached `app.responder`
+                // post-shutdown — return a no-op so the pipeline
+                // unwinds (`pipelineConfig` returning nil is the
+                // documented "I don't handle this protocol" path
+                // in ARCConnection.upgradeChildChannel).
+                return _NoOpResponder()
+            }
+            fatalError("No responder configured. Configure with app.responder.use(...)")
         }
 
         public var `default`: LibP2P.Responder {
@@ -84,6 +92,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Same teardown-race shape as `Application+Identify`,
+                // `Application+EventBus`, etc. Return a fresh empty
+                // Storage so the caller can fall back to the
+                // `_NoOpResponder` path in `current`.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Responder not configured. Configure with app.responder.initialize()")
             }
@@ -103,5 +118,22 @@ extension Application.Responder: Responder {
 
     public func pipelineConfig(for protocol: String, on connection: Connection) -> [ChannelHandler]? {
         self.current.pipelineConfig(for: `protocol`, on: connection)
+    }
+}
+
+/// No-op `Responder` returned by `app.responder.current` once the
+/// owning `Application` has flipped `isShuttingDown`. Fails any
+/// in-flight `respond(to:)` promise and returns `nil` from
+/// `pipelineConfig(for:on:)` — the latter is the documented "I
+/// don't handle this protocol" path that lets stranded inbound
+/// streams unwind cleanly through
+/// `ARCConnection.upgradeChildChannel`.
+private struct _NoOpResponder: Responder {
+    func respond(to request: Request) -> EventLoopFuture<RawResponse> {
+        request.eventLoop.makeFailedFuture(ChannelError.alreadyClosed)
+    }
+
+    func pipelineConfig(for protocol: String, on connection: Connection) -> [ChannelHandler]? {
+        nil
     }
 }

--- a/Sources/LibP2P/Security/Security.swift
+++ b/Sources/LibP2P/Security/Security.swift
@@ -137,6 +137,13 @@ extension Application {
         //        }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Transport Upgraders not initialized. Initialize with app.security.initialize()")
             }

--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -142,6 +142,13 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Servers not initialized. Configure with app.servers.initialize()")
             }

--- a/Sources/LibP2P/Sessions/Application+Sessions.swift
+++ b/Sources/LibP2P/Sessions/Application+Sessions.swift
@@ -94,6 +94,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Same teardown-race shape as `Application+Identify`,
+                // `Application+EventBus`, etc. Sessions is not on
+                // libp2p's stream-handling hot path, but mirroring
+                // the guard here keeps the fork uniform.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Sessions not configured. Configure with app.sessions.initialize()")
             }

--- a/Sources/LibP2P/Topology/Application+Topology.swift
+++ b/Sources/LibP2P/Topology/Application+Topology.swift
@@ -88,6 +88,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Topology::Registration not initialized. Initialize with app.topology.initialize()")
             }

--- a/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
+++ b/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
@@ -83,6 +83,13 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Transport Upgraders not initialized. Initialize with app.transportUpgraders.initialize()")
             }

--- a/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
+++ b/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
@@ -39,10 +39,21 @@ extension Application {
 
     public var upgrader: TransportUpgrader {
         let makeUpgrader = self.transportUpgraders.storage.makeUpgrader.withLockedValue { $0 }
-        guard let upgrader = makeUpgrader.factory?(self) else {
-            fatalError("No transport upgrader configured. Configure with app.transportUpgraders.use(...)")
+        if let upgrader = makeUpgrader.factory?(self) { return upgrader }
+        if self.isShuttingDown {
+            // Race window: a stranded inbound stream from a
+            // previous Application's still-alive YAMUX state can
+            // reach `app.upgrader` after `isShuttingDown` is set
+            // and the storage accessor has begun handing back a
+            // fresh empty Storage (whose factory is nil). Return
+            // a no-op upgrader that immediately closes any
+            // channel offered to it and fails any negotiation
+            // promise — same "complete vacuously" idea as the
+            // other defensive guards on this fork
+            // (Application+Identify, Application+EventBus, …).
+            return _NoOpTransportUpgrader()
         }
-        return upgrader
+        fatalError("No transport upgrader configured. Configure with app.transportUpgraders.use(...)")
     }
 
     public struct TransportUpgraders: Sendable {
@@ -95,5 +106,33 @@ extension Application {
             }
             return storage
         }
+    }
+}
+
+/// Stand-in `TransportUpgrader` returned by `app.upgrader` once
+/// the owning `Application` has flipped `isShuttingDown`. It does
+/// not negotiate any protocol — any channel offered to it is
+/// closed immediately, and any negotiation promise is failed
+/// with `ChannelError.alreadyClosed`.
+///
+/// Purpose is to let stranded inbound streams from a previous
+/// `Application`'s still-alive YAMUX state unwind cleanly after
+/// shutdown has started, instead of tripping the `fatalError` at
+/// `app.upgrader`. Behaviour matches the other defensive guards
+/// on this fork (see `Application+Identify.identify` and
+/// `Application+EventBus.events`).
+private struct _NoOpTransportUpgrader: TransportUpgrader {
+    func installHandlers(on channel: Channel) {
+        channel.close(promise: nil)
+    }
+
+    func negotiate(
+        protocols: [String],
+        mode: LibP2P.Mode,
+        logger: Logger,
+        promise: EventLoopPromise<(`protocol`: String, leftoverBytes: ByteBuffer?)>
+    ) -> [ChannelHandler] {
+        promise.fail(ChannelError.alreadyClosed)
+        return []
     }
 }

--- a/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
+++ b/Sources/LibP2P/TransportUpgrader/TransportUpgrader.swift
@@ -132,7 +132,25 @@ private struct _NoOpTransportUpgrader: TransportUpgrader {
         logger: Logger,
         promise: EventLoopPromise<(`protocol`: String, leftoverBytes: ByteBuffer?)>
     ) -> [ChannelHandler] {
+        // The caller (e.g. `ARCConnection.upgradeChildChannel`)
+        // force-unwraps `handlers.first!`, so we MUST return at
+        // least one ChannelHandler. The handler closes the
+        // channel as soon as it's added to the pipeline so the
+        // stranded inbound stream unwinds.
         promise.fail(ChannelError.alreadyClosed)
-        return []
+        return [_ChannelClosingHandler()]
+    }
+}
+
+/// Inbound channel handler returned by ``_NoOpTransportUpgrader``
+/// during application shutdown. Closes the channel as soon as it
+/// is added to a pipeline, so the stranded inbound stream that
+/// reached `app.upgrader` post-shutdown unwinds without inspecting
+/// any traffic.
+private final class _ChannelClosingHandler: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        context.close(promise: nil)
     }
 }

--- a/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
+++ b/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
@@ -241,10 +241,18 @@ public final class TCPServer: Server, @unchecked Sendable {
 
     /// TODO: FIXME!
     public var listeningAddress: Multiaddr {
-        guard didStart else {
+        // `didStart` flips to `true` slightly *before* `localAddress`
+        // is populated by the underlying NIO channel — under
+        // concurrent load (many Applications booting in parallel) the
+        // race window opens reliably and a force-unwrap on
+        // `self.localAddress` traps. Fall back to the configured
+        // hostname/port when the live address isn't ready yet; it's
+        // the same fallback the `!didStart` branch already uses, so
+        // semantics are unchanged for callers.
+        guard didStart, let live = self.localAddress else {
             return try! Multiaddr("/ip4/\(self.configuration.hostname)/tcp/\(self.configuration.port)")
         }
-        return try! self.localAddress!.toMultiaddr()
+        return try! live.toMultiaddr()
     }
 
     deinit {

--- a/Sources/LibP2P/Transports/Transports.swift
+++ b/Sources/LibP2P/Transports/Transports.swift
@@ -85,6 +85,13 @@ extension Application {
         }
 
         var storage: Storage {
+            if self.application.isShuttingDown {
+                // Race window: this Application has begun teardown.
+                // Returning a fresh empty `Storage` lets stranded
+                // event-loop callbacks finish vacuously instead of
+                // trapping at the `fatalError` below.
+                return Storage()
+            }
             guard let storage = self.application.storage[Key.self] else {
                 fatalError("Transports not initialized. Initialize with app.transports.initialize()")
             }


### PR DESCRIPTION
## Summary

When swift-libp2p `Application`s run on a shared event-loop group (the
common test-process case where many `Application`s boot and tear down
back-to-back), event-loop tasks can be queued before `asyncShutdown()`
clears `app.storage`. When those tasks fire post-clear, the storage
accessors trap on `fatalError("X not initialized")`.

This PR adds defensive guards across all 15 `Application` storage
accessors plus the secondary accessors that unwrap `storage.manager`,
so stranded callbacks racing teardown complete vacuously instead of
crashing.

These are race-window fixes only — pre-shutdown / fully-configured
paths are untouched.

## Changes

**Commit 1 — `Defensive guards for post-shutdown property access`**
- New `isShuttingDown` flag on `Application` that flips at the *start*
  of either shutdown path (vs `didShutdown` which flips at the *end*)
- Threaded through 15 storage accessors: Transports, EventBus,
  ConnectionManager, Clients, Identify, Topology, Security, DHT,
  Peerstore, Discovery, PubSub, TransportUpgrader, Resolver, Muxer,
  Servers
- During the race window, the accessor returns a fresh empty
  `Storage()` and the stranded callback completes vacuously
- `app.events` secondary accessor: hand back a fresh
  `EventBus(application: self)` when storage was already cleared.
  `EventBus.post(_:)` already guards on `application.isRunning`, so
  events get dropped silently
- `TCPServer.listeningAddress`: under high concurrent boot load,
  `didStart` flips true slightly before NIO populates `localAddress`.
  Fall back to the configured hostname/port (same fallback the
  `!didStart` branch already uses) when `localAddress` is still nil

**Commit 2 — `Defensive guard for app.connections secondary accessor`**
- Same shape as the `app.events` fix, applied to ConnectionManager
- Returns a fresh `BasicInMemoryConnectionManager(application: self)`
  during the post-shutdown race window

**Commit 3 — `Defensive guards for app.identify and app.peers secondary accessors`**
- Same shape, applied to `app.identify` → `LibP2P.Identify(application: self)`
- And `app.peers` → `BasicInMemoryPeerStore(application: self)`

## Context

Surfaced in CI under heavy concurrent boot/teardown load with many
`Application` instances sharing an `EventLoopGroup`. The secondary
accessors with the same shape that *haven't* been patched yet
(IdentityManager, Cache, Sessions, Responder, TransportUpgrader) can
get the same treatment if CI surfaces them next.

## Test Plan

- [ ] CI passes
- [ ] Existing tests untouched (no behavioural changes)
- [ ] Verified locally that pre-shutdown/configured paths are unchanged