### PR TITLE
Never advertise the 0.0.0.0 wildcard; add external-address override (align with rust-libp2p)

### DIFF
--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -207,21 +207,13 @@ extension Identify {
     /// - This message is ready to be sent to a remote peer who's opened a new `/ipfs/id/1.0.0` stream on our connection
     internal func constructIdentifyMessage(req: Request) throws -> [UInt8] {
         //Construct our Local Nodes Identify Message
-        let listenAddrs: [Multiaddr]
-
-        if req.addr.isInternalAddress {
-            /// A computer on our network is reaching out to us, respond with internal addresses...
-            req.logger.trace(
-                "Identify::A computer on our network is reaching out to us, responding with internal addresses..."
-            )
-            listenAddrs = req.application.listenAddresses
-        } else {
-            /// A computer outside of our network is asking for our ID, respond with externally reachable addresses only...
-            req.logger.trace(
-                "Identify::A computer outside of our network is asking for our ID, responding with externally reachable addresses only..."
-            )
-            listenAddrs = req.application.listenAddresses.stripInternalAddresses()
-        }
+        //
+        // Advertise the announce override unioned with our (wildcard-expanded)
+        // listen addresses, scoped to the caller (internal callers may receive
+        // internal addresses) and with the unspecified/wildcard address stripped
+        // as a backstop. Previously this advertised raw `listenAddresses`, which
+        // could leak `/ip4/0.0.0.0/...` to peers and poison their peerstore.
+        let listenAddrs = req.application.advertisedAddresses(forRemote: req.addr.isInternalAddress)
 
         var id = IdentifyMessage()
         id.publicKey = try self.localPeerID.keyPair!.publicKey.marshal()

--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -35,15 +35,64 @@ extension Application {
     public var listenAddresses: [Multiaddr] {
         self.servers.allServers.reduce(into: [Multiaddr]()) { partialResult, server in
             partialResult.append(server.listeningAddress)
-        }.map { ma in
-            if let tcp = ma.tcpAddress, tcp.address == "0.0.0.0",
-                let en0 = (try? self.getSystemAddress(forDevice: "en0"))?.address?.ipAddress
-            {
-                return (try? ma.swap(address: en0, forCodec: .ip4)) ?? ma
-            } else {
-                return ma
-            }
+        }.flatMap { ma -> [Multiaddr] in
+            // Expand an unspecified (`0.0.0.0`) bind address into one concrete
+            // multiaddr per non-loopback interface, mirroring rust-libp2p's
+            // transport-level `if_watch` expansion, so the wildcard never
+            // reaches the address-advertisement path. (The previous behavior
+            // swapped only the hardcoded `en0` interface and silently leaked
+            // raw `0.0.0.0` on any host whose primary interface wasn't `en0` —
+            // e.g. Wi-Fi/`en1`.) Never returns empty for a bound server, so
+            // callers that need `listenAddresses.first` keep a usable address.
+            guard let tcp = ma.tcpAddress, tcp.address == "0.0.0.0" else { return [ma] }
+            let interfaceIPs = self.getAllSystemAddresses()
+            guard !interfaceIPs.isEmpty else { return [ma] }
+            return interfaceIPs.compactMap { try? ma.swap(address: $0, forCodec: .ip4) }
         }
+    }
+
+    // MARK: - Advertised addresses
+
+    private struct AnnouncedAddressesKey: StorageKey {
+        typealias Value = [Multiaddr]
+    }
+
+    /// Externally-reachable multiaddrs to advertise to remote peers in addition
+    /// to (or, with ``hideListenAddrs``, instead of) this node's listen
+    /// addresses — the swift-libp2p analogue of rust-libp2p's
+    /// `Swarm::add_external_address` `external_addresses` set. Empty by default.
+    /// Set from config for a NAT'd node that knows its public name, which no
+    /// local interface enumeration can discover. Does not bind any socket.
+    public var announcedAddresses: [Multiaddr] {
+        get { self.storage[AnnouncedAddressesKey.self] ?? [] }
+        set { self.storage[AnnouncedAddressesKey.self] = newValue }
+    }
+
+    private struct HideListenAddrsKey: StorageKey {
+        typealias Value = Bool
+    }
+
+    /// When true, advertise only ``announcedAddresses`` (not the node's listen
+    /// addresses) — mirrors rust-libp2p's
+    /// `identify::Config::with_hide_listen_addrs`. For a pure-WAN node that
+    /// should publish only its public name.
+    public var hideListenAddrs: Bool {
+        get { self.storage[HideListenAddrsKey.self] ?? false }
+        set { self.storage[HideListenAddrsKey.self] = newValue }
+    }
+
+    /// The address set to advertise to a remote peer: the announce override
+    /// unioned with listen addresses (rust-libp2p's `all_addresses()`), scoped
+    /// to the caller (internal callers may receive internal addresses), with the
+    /// wildcard stripped as a backstop. Consumed by Identify and the DHT
+    /// provider-record path so both advertise an identical, never-wildcard set.
+    public func advertisedAddresses(forRemote remoteIsInternal: Bool) -> [Multiaddr] {
+        var base = self.announcedAddresses
+        if !self.hideListenAddrs {
+            base += self.listenAddresses
+        }
+        let scoped = remoteIsInternal ? base : base.stripInternalAddresses()
+        return scoped.stripUnspecifiedAddresses()
     }
 
     public struct Servers: Sendable {

--- a/Sources/LibP2P/Servers/Server.swift
+++ b/Sources/LibP2P/Servers/Server.swift
@@ -71,4 +71,13 @@ extension Array where Element == Multiaddr {
     public func stripInternalAddresses() -> [Multiaddr] {
         self.filter { !$0.isInternalAddress }
     }
+
+    /// Drops unspecified/wildcard addresses (IPv4 `0.0.0.0`, IPv6 `::`). Applied
+    /// at the address-advertisement boundary as a backstop: the wildcard should
+    /// already be expanded to concrete interface addresses by
+    /// `Application.listenAddresses`, but this guarantees a wildcard never
+    /// reaches a remote peer even on hosts where interface enumeration fails.
+    public func stripUnspecifiedAddresses() -> [Multiaddr] {
+        self.filter { !$0.isUnspecifiedAddress }
+    }
 }

--- a/Sources/LibP2P/Transports/Transports+Manager.swift
+++ b/Sources/LibP2P/Transports/Transports+Manager.swift
@@ -104,4 +104,15 @@ extension Multiaddr {
         let desc = self.description
         return desc.contains("127.0.0.1") || desc.contains("::1") || desc.contains("192.168.")
     }
+
+    /// True when this multiaddr's IP component is the unspecified/wildcard
+    /// address (IPv4 `0.0.0.0` or IPv6 `::`). A wildcard is a *bind* address,
+    /// never a dialable destination, so it must never be advertised to remote
+    /// peers. Parsed via `tcpAddress` (not a substring match) so a real address
+    /// like `10.0.0.0` — which *contains* the substring `0.0.0.0` — is not
+    /// misclassified.
+    public var isUnspecifiedAddress: Bool {
+        guard let tcp = self.tcpAddress else { return false }
+        return tcp.address == "0.0.0.0" || tcp.address == "::"
+    }
 }

--- a/Sources/LibP2P/Utilities/SystemAddresses+Application.swift
+++ b/Sources/LibP2P/Utilities/SystemAddresses+Application.swift
@@ -24,4 +24,26 @@ extension Application {
         guard let device = devices.first else { throw Errors.noAddressForDevice }
         return device
     }
+
+    /// Returns the IPv4 address string of every non-loopback, non-link-local
+    /// network interface. Used to expand an unspecified (`0.0.0.0`) listen
+    /// address into one concrete multiaddr per interface, mirroring
+    /// rust-libp2p's transport-level `if_watch` expansion — so the wildcard
+    /// never reaches the address-advertisement path. Returns an empty array if
+    /// enumeration fails or no routable interface exists; callers keep the
+    /// original (wildcard) address in that case and rely on the
+    /// strip-unspecified backstop at the advertise boundary.
+    func getAllSystemAddresses() -> [String] {
+        let devices = (try? System.enumerateDevices()) ?? []
+        var seen = Set<String>()
+        return devices.compactMap { device -> String? in
+            guard device.address != nil else { return nil }
+            guard let ma = try? device.address?.toMultiaddr().tcpAddress, ma.ip4 else { return nil }
+            guard let ip = device.address?.ipAddress else { return nil }
+            // Exclude loopback and IPv4 link-local (169.254.0.0/16): neither is
+            // a useful address to advertise to other peers.
+            if ip == "127.0.0.1" || ip.hasPrefix("169.254.") { return nil }
+            return seen.insert(ip).inserted ? ip : nil
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`Application.listenAddresses` only swapped a **hardcoded `en0`** interface for a `0.0.0.0` bind. On any host whose primary interface isn't `en0` (e.g. Wi-Fi / `en1`), raw `/ip4/0.0.0.0/...` leaked to remote peers through Identify. A peer that learns `0.0.0.0` dials it and fails (connection refused) — it poisons the remote peerstore and breaks a large fraction of cross-machine cold connections.

A wildcard is a *bind* address, never a dialable destination, so it must never be advertised.

## Fix — align with rust-libp2p

rust-libp2p never advertises the unspecified address: its transports expand `0.0.0.0` to concrete per-interface addresses (`if-watch`), and Identify advertises the listen set plus an explicit external-address set. This change mirrors that:

- **`listenAddresses`** expands an unspecified bind into one concrete multiaddr per non-loopback, non-link-local interface (`getAllSystemAddresses`), mirroring rust-libp2p's `if_watch` transport-level expansion — so `0.0.0.0` never enters the advertised set. Loopback and IPv4 link-local (`169.254/16`) are excluded.
- **`isUnspecifiedAddress` + `stripUnspecifiedAddresses`** backstop the advertise boundary for hosts where enumeration fails. `isUnspecifiedAddress` parses via `tcpAddress` (not a substring match), so a real address like `10.0.0.0` isn't misclassified.
- **`announcedAddresses`** — externally-reachable multiaddrs to advertise in addition to listen addresses (the analogue of rust-libp2p's `Swarm::add_external_address` / `external_addresses`). Empty by default; for a NAT'd node that knows its public name, which no interface enumeration can discover. Binds no socket.
- **`hideListenAddrs`** — advertise only `announcedAddresses` (mirrors rust-libp2p's `identify::Config::with_hide_listen_addrs`), for a pure-WAN node.
- **`advertisedAddresses(forRemote:)`** composes announce ∪ listen, internal-scoping, and the wildcard strip (the analogue of rust-libp2p's `all_addresses()`); Identify advertises through it, so internal vs external callers get appropriately scoped, never-wildcard sets.

## Notes

- Backward compatible: default behavior for a normally-bound node is unchanged except that `0.0.0.0` is now correctly expanded/stripped; `announcedAddresses`/`hideListenAddrs` default to empty/false.
- `listenAddresses` never returns empty for a bound server, so callers relying on `.first` keep a usable address.
- Builds clean against `main`.