### PR TITLE
Misc Work

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // LibP2P Core
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.4.2")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.5.0")),
         // LibP2P Multiaddr
         .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.2.0")),
         // LibP2P Peer Identities

--- a/Package.swift
+++ b/Package.swift
@@ -29,11 +29,11 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // LibP2P Core
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.4.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.4.2")),
         // LibP2P Multiaddr
         .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.2.0")),
         // LibP2P Peer Identities
-        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMinor(from: "0.2.1")),
+        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMinor(from: "0.2.2")),
         // Swift NIO for all things networking
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.87.0")),
         .package(url: "https://github.com/apple/swift-nio-extras.git", .upToNextMajor(from: "1.25.0")),

--- a/Sources/LibP2P/Connections/ARCConnection.swift
+++ b/Sources/LibP2P/Connections/ARCConnection.swift
@@ -666,9 +666,13 @@ public class ARCConnection: AppConnection, @unchecked Sendable {
                 self.newStreamCache.append(pendingStream)
                 /// Ask our installed Muxer to open / initialize a new stream for us...
                 self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
-                try! mux.newStream(channel: self.channel, proto: proto).whenSuccess { stream in
-                    //print("Skipping Stream Registry")
-                    //self.registry[stream.id] = stream
+                do {
+                    let streamFuture = try mux.newStream(channel: self.channel, proto: proto)
+                    streamFuture.whenFailure { error in
+                        self.logger.error("Muxer failed to open new stream for protocol `\(proto)`: \(error)")
+                    }
+                } catch {
+                    self.logger.error("Muxer threw while opening new stream for protocol `\(proto)`: \(error)")
                 }
 
             } else {
@@ -682,6 +686,12 @@ public class ARCConnection: AppConnection, @unchecked Sendable {
     public func newStreamSync(_ proto: String) throws -> LibP2PCore.Stream {
         let stream: _Stream
         if isMuxed, let mux = self.muxer {
+            // A synchronous API must never block the very event loop it depends on to make
+            // progress — doing so would deadlock. Callers on the loop must use the async
+            // `newStream(_:)` / `newStream(forProtocol:)` APIs instead.
+            guard !self.channel.eventLoop.inEventLoop else {
+                throw Application.Connections.Errors.cannotBlockEventLoop
+            }
             // Ask our installed Muxer to open / initialize a new stream for us...
             self.logger.debug("Asking Muxer to open / initialize new stream")
             stream = try mux.newStream(channel: self.channel, proto: proto).wait()

--- a/Sources/LibP2P/Connections/BasicConnectionLight.swift
+++ b/Sources/LibP2P/Connections/BasicConnectionLight.swift
@@ -550,9 +550,13 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
                 self.newStreamCache.append(pendingStream)
                 /// Ask our installed Muxer to open / initialize a new stream for us...
                 self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
-                try! mux.newStream(channel: self.channel, proto: proto).whenSuccess { stream in
-                    //print("Skipping Stream Registry")
-                    //self.registry[stream.id] = stream
+                do {
+                    let streamFuture = try mux.newStream(channel: self.channel, proto: proto)
+                    streamFuture.whenFailure { error in
+                        self.logger.error("Muxer failed to open new stream for protocol `\(proto)`: \(error)")
+                    }
+                } catch {
+                    self.logger.error("Muxer threw while opening new stream for protocol `\(proto)`: \(error)")
                 }
 
             } else {
@@ -566,6 +570,12 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
     public func newStreamSync(_ proto: String) throws -> LibP2PCore.Stream {
         let stream: _Stream
         if isMuxed, let mux = self.muxer {
+            // A synchronous API must never block the very event loop it depends on to make
+            // progress — doing so would deadlock. Callers on the loop must use the async
+            // `newStream(_:)` / `newStream(forProtocol:)` APIs instead.
+            guard !self.channel.eventLoop.inEventLoop else {
+                throw Application.Connections.Errors.cannotBlockEventLoop
+            }
             // Ask our installed Muxer to open / initialize a new stream for us...
             self.logger.debug("Asking Muxer to open / initialize new stream")
             stream = try mux.newStream(channel: self.channel, proto: proto).wait()

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -46,6 +46,9 @@ extension Application {
             case failedToCloseAllStreams
             case noStreamForID(UInt64)
             case timedOut
+            /// Thrown when a synchronous, blocking API (e.g. `newStreamSync`) is invoked from the
+            /// connection's own event loop, which would deadlock. Use the async/future API instead.
+            case cannotBlockEventLoop
         }
 
         public struct Provider {

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -68,7 +68,11 @@ public final class Identify: IdentityManager, CustomStringConvertible {
         self.pingCache = .init([:])
 
         /// Register our protocol route handler on the application...
-        try! routes(application)
+        do {
+            try routes(application)
+        } catch {
+            self.logger.critical("Identify::Failed to register protocol routes: \(error)")
+        }
 
         /// Register our event listeners
         application.events.on(self, event: .upgraded(self.onNewConnection))
@@ -148,7 +152,7 @@ extension Identify {
             /// Publish the identifiedPeer event
             self.application?.events.post(
                 .identifiedPeer(
-                    IdentifiedPeer(peer: peerRecord.peerID, identity: try! remoteIdentify.serializedData().byteArray)
+                    IdentifiedPeer(peer: peerRecord.peerID, identity: try remoteIdentify.serializedData().byteArray)
                 )
             )
 
@@ -380,7 +384,12 @@ extension Identify {
                     startTime: DispatchTime.now().uptimeNanoseconds,
                     promise: promise
                 )
-                try! self.application!.newStream(to: peer, forProtocol: Identify.Multicodecs.PING)
+                do {
+                    try self.application!.newStream(to: peer, forProtocol: Identify.Multicodecs.PING)
+                } catch {
+                    pings.removeValue(forKey: peer.id)
+                    promise.fail(error)
+                }
                 return promise.futureResult
             }
         }
@@ -411,7 +420,12 @@ extension Identify {
                     startTime: DispatchTime.now().uptimeNanoseconds,
                     promise: promise
                 )
-                try! self.application!.newStream(to: addr, forProtocol: Identify.Multicodecs.PING)
+                do {
+                    try self.application!.newStream(to: addr, forProtocol: Identify.Multicodecs.PING)
+                } catch {
+                    pings.removeValue(forKey: peer.id)
+                    promise.fail(error)
+                }
                 return promise.futureResult
             }
         }
@@ -423,7 +437,11 @@ extension Identify {
             req.shouldClose()
             return nil
         }
-        let bytes: [UInt8] = try! LibP2PCrypto.randomBytes(length: 32)
+        guard let bytes: [UInt8] = try? LibP2PCrypto.randomBytes(length: 32) else {
+            req.logger.error("Identify::Outbound Ping failed to generate a random payload")
+            req.shouldClose()
+            return nil
+        }
         let startTime = DispatchTime.now().uptimeNanoseconds
         /// Check to see if this ping was initiated by our IndetifyManager...
         self.el.execute {
@@ -451,6 +469,11 @@ extension Identify {
                     return
                 }
 
+                guard let remotePeer = req.remotePeer else {
+                    req.logger.error("Identify::Cannot record ping latency for an unauthenticated stream")
+                    return
+                }
+
                 /// Determine to total round trip time in nanoseconds
                 let toc = DispatchTime.now().uptimeNanoseconds - pendingPing.startTime
 
@@ -463,7 +486,7 @@ extension Identify {
                 req.logger.trace("Identify::Ping updating \(isConnection ? "connection" : "stream") latency")
 
                 /// Update our peers metadata
-                req.application.peers.getMetadata(forPeer: req.remotePeer!).flatMap {
+                req.application.peers.getMetadata(forPeer: remotePeer).flatMap {
                     metadata -> EventLoopFuture<Void> in
                     let new: MetadataBook.LatencyMetadata
                     if let existingLatencyData = metadata[MetadataBook.Keys.Latency.rawValue],
@@ -498,13 +521,16 @@ extension Identify {
                     }
 
                     /// Encode New Latency Data and store it...
-                    let newData = try! JSONEncoder().encode(new)
+                    guard let newData = try? JSONEncoder().encode(new) else {
+                        req.logger.error("Identify::Failed to encode latency metadata")
+                        return req.eventLoop.makeSucceededVoidFuture()
+                    }
 
                     /// Store it!
                     return req.application.peers.add(
                         metaKey: MetadataBook.Keys.Latency,
                         data: newData.byteArray,
-                        toPeer: req.remotePeer!
+                        toPeer: remotePeer
                     )
                 }.whenComplete({ _ in
                     req.logger.trace("Identify::Ping Time to Peer<\(pendingPing.peer.prefix(7))> == \(toc)ns")

--- a/Sources/LibP2P/Responder/CommonChannelHandlers/VarIntLengthPrefixHandlers.swift
+++ b/Sources/LibP2P/Responder/CommonChannelHandlers/VarIntLengthPrefixHandlers.swift
@@ -27,6 +27,14 @@
 import NIO
 import SwiftProtobuf
 
+/// Errors thrown while decoding a VarInt length prefix from an inbound (potentially malicious) byte stream.
+public enum VarIntDecodingError: Error, Equatable {
+    /// The inbound bytes did not form a valid varint — it either overflowed 64 bits
+    /// or encoded a length larger than `Int.max`. The frame is malformed; the channel
+    /// should be errored/closed rather than crashing the process.
+    case invalidVarInt
+}
+
 extension Application.ChildChannelHandlers.Provider {
 
     /// `varIntLengthPrefixed` installs two channelHandlers that help decode and encode frames who are denoted by a VarInt length prefix
@@ -73,7 +81,7 @@ public class VarintFrameDecoder: ByteToMessageDecoder {
     public func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
         // If we don't have a length, we need to read one
         if self.messageLength == nil {
-            self.messageLength = buffer.readVarint()
+            self.messageLength = try buffer.readVarint()
         }
         guard let length = self.messageLength else {
             // Not enough bytes to read the message length. Ask for more.
@@ -124,7 +132,7 @@ public class VarintLengthFieldPrepender: MessageToByteEncoder {
 }
 
 extension ByteBuffer {
-    fileprivate mutating func readVarint() -> Int? {
+    fileprivate mutating func readVarint() throws -> Int? {
         var value: UInt64 = 0
         var shift: UInt64 = 0
         let initialReadIndex = self.readerIndex
@@ -138,11 +146,18 @@ extension ByteBuffer {
 
             value |= UInt64(c & 0x7F) << shift
             if c & 0x80 == 0 {
+                // A length larger than `Int.max` cannot be represented and is treated as malformed
+                // rather than trapping on the `Int(value)` conversion.
+                guard value <= UInt64(Int.max) else {
+                    throw VarIntDecodingError.invalidVarInt
+                }
                 return Int(value)
             }
             shift += 7
             if shift > 63 {
-                fatalError("Invalid varint, requires shift (\(shift)) > 64")
+                // A valid 64-bit varint is at most 10 bytes; a continuation past bit 63 is
+                // malformed input from the remote peer. Error the frame instead of crashing.
+                throw VarIntDecodingError.invalidVarInt
             }
         }
     }

--- a/Sources/LibP2P/Utilities/KeyPairFile.swift
+++ b/Sources/LibP2P/Utilities/KeyPairFile.swift
@@ -388,10 +388,12 @@ public enum KeyPairFile {
         case .some(let pwd):
             // TODO check app for testing environment and use a smaller pbkdf iteration when so (speed up tests)
             if environment == .testing {
-                pem = try peerID.exportKeyPair(as: .privatePEMString(
-                    encryptedWithPassword: pwd,
-                    usingPBKDF: .pbkdf2(salt: LibP2PCrypto.random16ByteSalt(), iterations: 2048)
-                ))
+                pem = try peerID.exportKeyPair(
+                    as: .privatePEMString(
+                        encryptedWithPassword: pwd,
+                        usingPBKDF: .pbkdf2(salt: LibP2PCrypto.random16ByteSalt(), iterations: 2048)
+                    )
+                )
             } else {
                 // Export with the strong defaults
                 pem = try peerID.exportKeyPair(as: .privatePEMString(encryptedWithPassword: pwd))

--- a/Sources/LibP2P/Utilities/KeyPairFile.swift
+++ b/Sources/LibP2P/Utilities/KeyPairFile.swift
@@ -386,7 +386,16 @@ public enum KeyPairFile {
         let pem: String
         switch try await encryption.password(for: environment) {
         case .some(let pwd):
-            pem = try peerID.exportKeyPair(as: .privatePEMString(encryptedWithPassword: pwd))
+            // TODO check app for testing environment and use a smaller pbkdf iteration when so (speed up tests)
+            if environment == .testing {
+                pem = try peerID.exportKeyPair(as: .privatePEMString(
+                    encryptedWithPassword: pwd,
+                    usingPBKDF: .pbkdf2(salt: LibP2PCrypto.random16ByteSalt(), iterations: 2048)
+                ))
+            } else {
+                // Export with the strong defaults
+                pem = try peerID.exportKeyPair(as: .privatePEMString(encryptedWithPassword: pwd))
+            }
         case .none:
             // TODO: issue warning (especially in production environments)
             pem = try peerID.exportKeyPair(as: .unencrypredPrivatePEMString)

--- a/Tests/LibP2PTests/VarintFrameDecoderTests.swift
+++ b/Tests/LibP2PTests/VarintFrameDecoderTests.swift
@@ -24,16 +24,16 @@ extension LibP2PTests {
     ///
     /// A malformed varint on an inbound (potentially malicious) stream previously crashed the whole
     /// process via `fatalError` / an `Int(value)` overflow trap. The decoder now throws
-    /// `VarintDecodingError.invalidVarint`, which NIO surfaces as a channel error so only the
+    /// `VarIntDecodingError.invalidVarInt`, which NIO surfaces as a channel error so only the
     /// offending peer's connection is torn down.
-    @Suite("VarintFrameDecoderTests")
-    struct VarintFrameDecoderTests {
+    @Suite("VarIntFrameDecoderTests")
+    struct VarIntFrameDecoderTests {
 
-        /// The raw decoder must throw `VarintDecodingError.invalidVarint` for both malformed shapes:
+        /// The raw decoder must throw `VarIntDecodingError.invalidVarInt` for both malformed shapes:
         /// an overlong varint (continuation past bit 63) and a terminating varint whose value
         /// overflows `Int.max`.
-        @Test("VarintFrameDecoder throws .invalidVarint on malformed varints")
-        func testInvalidVarintThrows() throws {
+        @Test("VarIntFrameDecoder throws .invalidVarInt on malformed varints")
+        func testInvalidVarIntThrows() throws {
             // Overlong: ten continuation bytes push `shift` past 63 before ever terminating.
             do {
                 let channel = EmbeddedChannel(handler: ByteToMessageHandler(VarintFrameDecoder()))

--- a/Tests/LibP2PTests/VarintFrameDecoderTests.swift
+++ b/Tests/LibP2PTests/VarintFrameDecoderTests.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import LibP2P
+
+extension LibP2PTests {
+
+    /// Regression tests for the VarInt length-prefix frame decoder.
+    ///
+    /// A malformed varint on an inbound (potentially malicious) stream previously crashed the whole
+    /// process via `fatalError` / an `Int(value)` overflow trap. The decoder now throws
+    /// `VarintDecodingError.invalidVarint`, which NIO surfaces as a channel error so only the
+    /// offending peer's connection is torn down.
+    @Suite("VarintFrameDecoderTests")
+    struct VarintFrameDecoderTests {
+
+        /// The raw decoder must throw `VarintDecodingError.invalidVarint` for both malformed shapes:
+        /// an overlong varint (continuation past bit 63) and a terminating varint whose value
+        /// overflows `Int.max`.
+        @Test("VarintFrameDecoder throws .invalidVarint on malformed varints")
+        func testInvalidVarintThrows() throws {
+            // Overlong: ten continuation bytes push `shift` past 63 before ever terminating.
+            do {
+                let channel = EmbeddedChannel(handler: ByteToMessageHandler(VarintFrameDecoder()))
+                defer { _ = try? channel.finish() }
+                var overlong = channel.allocator.buffer(capacity: 10)
+                overlong.writeBytes([UInt8](repeating: 0x80, count: 10))
+                #expect(throws: VarIntDecodingError.invalidVarInt) {
+                    try channel.writeInbound(overlong)
+                }
+            }
+
+            // Int.max overflow: nine 0x80 bytes followed by 0x01 encodes 2^63, one past `Int.max`.
+            do {
+                let channel = EmbeddedChannel(handler: ByteToMessageHandler(VarintFrameDecoder()))
+                defer { _ = try? channel.finish() }
+                var overflowing = channel.allocator.buffer(capacity: 10)
+                overflowing.writeBytes([UInt8](repeating: 0x80, count: 9) + [0x01])
+                #expect(throws: VarIntDecodingError.invalidVarInt) {
+                    try channel.writeInbound(overflowing)
+                }
+            }
+        }
+
+        /// The `varIntLengthPrefixed` handler pair must round-trip a well-formed frame and reject a
+        /// malformed length prefix by throwing (rather than crashing).
+        @Test("varInt length-prefix handlers round-trip and reject malformed frames")
+        func testLengthPrefixedHandlersRoundTripAndReject() throws {
+            let payloadBytes: [UInt8] = [0x41, 0x42, 0x43]  // "ABC"
+
+            // Encode a frame using the length-field prepender...
+            let encoder = EmbeddedChannel(handler: MessageToByteHandler(VarintLengthFieldPrepender()))
+            defer { _ = try? encoder.finish() }
+            var payload = encoder.allocator.buffer(capacity: payloadBytes.count)
+            payload.writeBytes(payloadBytes)
+            try encoder.writeOutbound(payload)
+            let framed = try #require(try encoder.readOutbound(as: ByteBuffer.self))
+
+            // The frame should be a single varint length byte (3) followed by the payload.
+            #expect(Array(framed.readableBytesView) == [0x03] + payloadBytes)
+
+            // ...and decode it back through the frame decoder to recover the original payload.
+            let decoder = EmbeddedChannel(handler: ByteToMessageHandler(VarintFrameDecoder()))
+            defer { _ = try? decoder.finish() }
+            try decoder.writeInbound(framed)
+            let decoded = try #require(try decoder.readInbound(as: ByteBuffer.self))
+            #expect(Array(decoded.readableBytesView) == payloadBytes)
+
+            // A malformed length prefix must throw instead of taking down the process.
+            let malformed = EmbeddedChannel(handler: ByteToMessageHandler(VarintFrameDecoder()))
+            defer { _ = try? malformed.finish() }
+            var badPrefix = malformed.allocator.buffer(capacity: 10)
+            badPrefix.writeBytes([UInt8](repeating: 0x80, count: 10))
+            #expect(throws: VarIntDecodingError.invalidVarInt) {
+                try malformed.writeInbound(badPrefix)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What?
- Removed a bunch of force unwraps, replaced with proper thrown errors
- Default PEM Encryption is much more secure, but significantly slower, so during tests (when ENV == .testing) we use a lower PBKDF iteration count to speed things up.
- `VarIntLengthPrefixed` handlers now throw on bad input, closing the connection, instead of crashing the entire node