### PR TITLE
EventBus

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,8 +49,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", .upToNextMajor(from: "1.19.0")),
         // Swift metrics API
         .package(url: "https://github.com/apple/swift-metrics.git", .upToNextMajor(from: "2.5.0")),
-        // Swift Event Bus
-        .package(url: "https://github.com/cesarferreira/SwiftEventBus.git", .upToNextMajor(from: "5.0.0")),
         // SwiftState for state machines
         .package(url: "https://github.com/ReactKit/SwiftState.git", .upToNextMajor(from: "6.0.0")),
     ],
@@ -75,7 +73,6 @@ let package = Package(
                 .product(name: "AsyncKit", package: "async-kit"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
                 .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "SwiftEventBus", package: "SwiftEventBus"),
                 .product(name: "SwiftState", package: "SwiftState"),
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .target(name: "COperatingSystem"),

--- a/Sources/LibP2P/Discovery/Application+Discovery.swift
+++ b/Sources/LibP2P/Discovery/Application+Discovery.swift
@@ -145,7 +145,7 @@ extension Application.DiscoveryServices {
         return discoveryService.advertise(service: proto, options: nil)
     }
 
-    public func onPeerDiscovered(_ register: AnyObject, closure: @escaping (PeerInfo) -> Void) {
+    public func onPeerDiscovered(_ register: AnyObject, closure: @escaping @Sendable (PeerInfo) -> Void) {
         application.events.on(register, event: .peerDiscovered(closure))
     }
 

--- a/Sources/LibP2P/EventBus/EventBus.swift
+++ b/Sources/LibP2P/EventBus/EventBus.swift
@@ -12,56 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LibP2PCore
-import SwiftEventBus
-
-/// https://github.com/libp2p/specs/blob/master/connections/README.md#connection-lifecycle-events
-extension SwiftEventBus {
-    /// Internal Events
-    internal struct _Event {
-        /// Called by our IdentifyManager when a Remote Peer has been successfully identified
-        static let IdentifiedPeer = "libp2p.identifiedPeer"
-    }
-
-    /// Public Events
-    public struct Event {
-        /// A new connection has been opened
-        static let Connected = "libp2p.connected"
-
-        /// A connection has closed
-        static let Disconnected = "libp2p.disconnected"
-
-        /// A new stream has opened over a connection
-        static let OpenedStream = "libp2p.streamOpened"
-
-        /// A stream has closed
-        static let ClosedStream = "libp2p.streamClosed"
-
-        /// We've started listening on a new address
-        static let Listen = "libp2p.listenOpened"
-
-        /// We've stopped listening on an address
-        static let ListenClose = "libp2p.listenClosed"
-
-        /// We've verified a connection to a remote peer
-        static let RemotePeer = "libp2p.remotePeerAdded"
-
-        /// Connection has been upgraded (both secured and has muxing capabilities)
-        static let Upgraded = "libp2p.connectionUpgraded"
-
-        /// Called by our IdentifyManager when a Remote Peer has been successfully identified
-        static let IdentifiedPeer = "libp2p.identifiedPeer"
-
-        /// Called by libp2p when a fully upgraded remote peers handled protocols change (usually after receiving an identify, identify/delta, message)
-        static let RemotePeerProtocolChange = "libp2p.remotePeerProtocolChange"
-
-        /// Called by libp2p when our locally handled protocols change
-        static let LocalProtocolChange = "libp2p.localProtocolChange"
-
-        /// Called by libp2p when a discovery service found a potential peer
-        static let PeerDiscovered = "libp2p.peerDiscovered"
-    }
-}
+import NIOConcurrencyHelpers
 
 extension Application.Events.Provider {
     public static var `default`: Self {
@@ -73,18 +26,91 @@ extension Application.Events.Provider {
     }
 }
 
+/// A lightweight, strict-concurrency event bus.
+///
+/// See https://github.com/libp2p/specs/blob/master/connections/README.md#connection-lifecycle-events
+///
+/// This is a native replacement for the previous `SwiftEventBus`/`NotificationCenter` backed
+/// implementation. It stores its subscribers in a single `NIOLockedValueBox`, mirroring the
+/// `Application` storage pattern, so the bus itself is a plain `Sendable` class with no actor
+/// isolation.
+///
+/// **Delivery is isolated per subscriber.** Both subscription styles are backed by the same
+/// mechanism: each subscriber owns a bounded `AsyncStream` continuation, and `post(_:)` merely
+/// `yield`s onto every interested continuation. Yielding is non-blocking, so a slow — or entirely
+/// unresponsive — subscriber can neither stall `post(_:)` nor starve any other subscriber; at worst
+/// it drops its own oldest buffered events. Events for a single subscriber are delivered in order.
+///
+/// Two ways to subscribe:
+///   * ``on(_:event:)`` — a classic callback keyed off an owning object's identity (removed with
+///     ``unregister(_:)``). The callback runs on a private drain `Task`, **not** synchronously on the
+///     posting thread; existing handlers already hop to their own event loops, so this is transparent.
+///   * ``subscribe(to:)`` / ``subscribe()`` — an `AsyncStream` of ``EventEmitter`` values for modern
+///     `for await` consumers. The stream cleans up its registration on termination.
 public final class EventBus: Sendable {
 
-    private let application: Application
-    private let instanceID: String
-    private let logger: Logger
+    /// The distinct event categories. Used purely as a subscription/dispatch key; both
+    /// ``EventEmitter`` (posts) and ``EventHandler`` (callback subscriptions) map onto it.
+    public enum Kind: Sendable, Hashable, CaseIterable {
+        /// A new connection has been opened.
+        case connected
+        /// A connection has closed.
+        case disconnected
+        /// A new stream has opened over a connection.
+        case openedStream
+        /// A stream has closed.
+        case closedStream
+        /// We've started listening on a new address.
+        case listen
+        /// We've stopped listening on an address.
+        case listenClosed
+        /// We've verified a connection to a remote peer.
+        case remotePeer
+        /// A connection has been upgraded (both secured and muxing-capable).
+        case upgraded
+        /// A remote peer has been successfully identified (via the Identify protocol).
+        case identifiedPeer
+        /// A fully upgraded remote peer's set of handled protocols changed (via Identify / Identify-Delta).
+        case remotePeerProtocolChange
+        /// Our own set of locally handled protocols changed.
+        case localProtocolChange
+        /// A discovery service found a potential peer.
+        case peerDiscovered
+    }
 
-    init(application: Application, instanceID: String? = nil) {
+    /// Maximum number of buffered events per subscriber (both callback and `AsyncStream`). A slow or
+    /// abandoned consumer drops its own oldest events rather than growing memory without bound or
+    /// applying backpressure to the poster.
+    private static let streamBufferSize = 64
+
+    /// Bookkeeping for one ``on(_:event:)`` callback subscription, so ``unregister(_:)`` can tear it
+    /// down: cancelling `task` ends its drain loop, whose stream `onTermination` removes the
+    /// continuation from the registry.
+    private struct CallbackToken {
+        let id: UUID
+        let kinds: Set<Kind>
+        let task: Task<Void, Never>
+    }
+
+    /// Everything mutable lives here, guarded by a single lock.
+    private struct Registry {
+        /// Every subscriber's continuation (callback drains and public `AsyncStream`s alike), keyed by
+        /// event kind then by a per-subscription token. `post(_:)` yields onto these.
+        var continuations: [Kind: [UUID: AsyncStream<EventEmitter>.Continuation]] = [:]
+        /// Callback subscriptions, grouped by the owning object's identity for ``unregister(_:)``.
+        var callbackTokens: [ObjectIdentifier: [CallbackToken]] = [:]
+    }
+
+    private let application: Application
+    private let logger: Logger
+    private let registry: NIOLockedValueBox<Registry>
+
+    init(application: Application) {
         self.application = application
-        self.instanceID = "." + (instanceID ?? UUID().uuidString)
+        self.registry = .init(Registry())
 
         var logger = application.logger
-        logger[metadataKey: "EventBus"] = .string("\(self.instanceID.dropFirst().prefix(5))")
+        logger[metadataKey: "EventBus"] = .string("\(UUID().uuidString.prefix(5))")
         self.logger = logger
 
         if !application.isShuttingDown {
@@ -92,7 +118,25 @@ public final class EventBus: Sendable {
         }
     }
 
-    public enum EventEmitter {
+    deinit {
+        // Tear down any subscriptions that outlived the bus: cancel the callback drain tasks and finish
+        // every continuation so awaiting consumers terminate cleanly. `onTermination` captures `self`
+        // weakly, so the `finish()` calls here don't re-enter the (now-deinitializing) bus.
+        let (tasks, continuations): ([Task<Void, Never>], [AsyncStream<EventEmitter>.Continuation]) =
+            self.registry.withLockedValue { registry in
+                (
+                    registry.callbackTokens.values.flatMap { $0 }.map { $0.task },
+                    registry.continuations.values.flatMap { $0.values }
+                )
+            }
+        for task in tasks { task.cancel() }
+        for continuation in continuations { continuation.finish() }
+    }
+
+    // MARK: - Event values
+
+    /// The events that can be posted onto the bus, carrying their (already `Sendable`) payload.
+    public enum EventEmitter: Sendable {
         case connected(Connection)
         case disconnected(Connection, PeerID?)
         case openedStream(LibP2PCore.Stream)
@@ -106,100 +150,58 @@ public final class EventBus: Sendable {
         case localProtocolChange
         case peerDiscovered(PeerInfo)
 
-        var eventName: String {
+        public var kind: Kind {
             switch self {
-            case .connected:
-                return SwiftEventBus.Event.Connected
-            case .disconnected:
-                return SwiftEventBus.Event.Disconnected
-            case .openedStream:
-                return SwiftEventBus.Event.OpenedStream
-            case .closedStream:
-                return SwiftEventBus.Event.ClosedStream
-            case .listen:
-                return SwiftEventBus.Event.Listen
-            case .listenClosed:
-                return SwiftEventBus.Event.ListenClose
-            case .remotePeer:
-                return SwiftEventBus.Event.RemotePeer
-            case .upgraded:
-                return SwiftEventBus.Event.Upgraded
-            case .identifiedPeer:
-                return SwiftEventBus.Event.IdentifiedPeer
-            case .remotePeerProtocolChange:
-                return SwiftEventBus.Event.RemotePeerProtocolChange
-            case .localProtocolChange:
-                return SwiftEventBus.Event.LocalProtocolChange
-            case .peerDiscovered:
-                return SwiftEventBus.Event.PeerDiscovered
+            case .connected: return .connected
+            case .disconnected: return .disconnected
+            case .openedStream: return .openedStream
+            case .closedStream: return .closedStream
+            case .listen: return .listen
+            case .listenClosed: return .listenClosed
+            case .remotePeer: return .remotePeer
+            case .upgraded: return .upgraded
+            case .identifiedPeer: return .identifiedPeer
+            case .remotePeerProtocolChange: return .remotePeerProtocolChange
+            case .localProtocolChange: return .localProtocolChange
+            case .peerDiscovered: return .peerDiscovered
             }
         }
-
-        var payload: Any? {
-            switch self {
-            case .connected(let connection):
-                return connection
-            case .disconnected(let connection, let pid):
-                return (connection, pid)
-            case .openedStream(let stream):
-                return stream
-            case .closedStream(let stream):
-                return stream
-            case .listen(let pid, let ma):
-                return (pid, ma)
-            case .listenClosed(let pid, let ma):
-                return (pid, ma)
-            case .remotePeer(let peer):
-                return peer
-            case .upgraded(let connection):
-                return connection
-            case .identifiedPeer(let peer):
-                return peer
-            case .remotePeerProtocolChange(let change):
-                return change
-            //            case .localProtocolChange:
-            //                return SwiftEventBus.Event.LocalProtocolChange
-            case .peerDiscovered(let pInfo):
-                return pInfo
-            default:
-                return nil
-            }
-        }
-
-        //        var expectedPayloadType:Any.Type {
-        //            switch self {
-        //            case .connected:
-        //                return Connection.self
-        //            default:
-        //                return Void.self
-        //            }
-        //        }
     }
 
-    /// Public Events Available For Subscription
-    public enum EventHandler {
-        case connected(_ cb: (Connection) -> Void)
-        case disconnected(_ cb: (Connection, PeerID?) -> Void)
-        case openedStream(_ cb: (LibP2PCore.Stream) -> Void)
-        case closedStream(_ cb: (LibP2PCore.Stream) -> Void)
-        case remotePeer(_ cb: (PeerInfo) -> Void)
-        case upgraded(_ cb: (Connection) -> Void)
-        case identifiedPeer(_ cb: (IdentifiedPeer) -> Void)
-        case peerDiscovered(_ cb: (PeerInfo) -> Void)
+    /// Public Events Available For Subscription via the callback API.
+    public enum EventHandler: Sendable {
+        case connected(_ cb: @Sendable (Connection) -> Void)
+        case disconnected(_ cb: @Sendable (Connection, PeerID?) -> Void)
+        case openedStream(_ cb: @Sendable (LibP2PCore.Stream) -> Void)
+        case closedStream(_ cb: @Sendable (LibP2PCore.Stream) -> Void)
+        case remotePeer(_ cb: @Sendable (PeerInfo) -> Void)
+        case upgraded(_ cb: @Sendable (Connection) -> Void)
+        case identifiedPeer(_ cb: @Sendable (IdentifiedPeer) -> Void)
+        case peerDiscovered(_ cb: @Sendable (PeerInfo) -> Void)
 
         /// What used to be internal subscriptions
-        case listen(_ cb: (String, Multiaddr) -> Void)
-        case listenClosed(_ cb: (String, Multiaddr) -> Void)
-        case remotePeerProtocolChange(_ cb: (LibP2P.RemotePeerProtocolChange) -> Void)
+        case listen(_ cb: @Sendable (String, Multiaddr) -> Void)
+        case listenClosed(_ cb: @Sendable (String, Multiaddr) -> Void)
+        case remotePeerProtocolChange(_ cb: @Sendable (LibP2P.RemotePeerProtocolChange) -> Void)
+
+        var kind: Kind {
+            switch self {
+            case .connected: return .connected
+            case .disconnected: return .disconnected
+            case .openedStream: return .openedStream
+            case .closedStream: return .closedStream
+            case .remotePeer: return .remotePeer
+            case .upgraded: return .upgraded
+            case .identifiedPeer: return .identifiedPeer
+            case .peerDiscovered: return .peerDiscovered
+            case .listen: return .listen
+            case .listenClosed: return .listenClosed
+            case .remotePeerProtocolChange: return .remotePeerProtocolChange
+            }
+        }
     }
 
-    /// Internal Events Available For Subscription
-    //    internal enum _EventHandler {
-    //        case listen(_ cb:(String, Multiaddr) -> Void)
-    //        case listenClosed(_ cb:(String, Multiaddr) -> Void)
-    //        //case identifiedPeer(_ cb:(IdentifiedPeer) -> Void)
-    //        case remotePeerProtocolChange(_ cb:(LibP2P.RemotePeerProtocolChange) -> Void)
-    //    }
+    // MARK: - Posting
 
     public func post(_ event: EventEmitter) {
         guard application.isRunning else {
@@ -207,161 +209,134 @@ public final class EventBus: Sendable {
             self.logger.error("\(event)")
             return
         }
-        SwiftEventBus.post(event.eventName + instanceID, sender: event.payload)
-    }
 
-    /// Can we extend this method to include a PeerID that will help silo events within instances of LibP2P?
-    public func on(_ register: AnyObject, event: EventHandler) {
-        switch event {
-        case .connected(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.Connected) {
-                notification in
-                guard let not = notification, let connection = not.object as? Connection else {
-                    return
-                }
-                return handler(connection)
-            }
-        case .disconnected(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.Disconnected) {
-                notification in
-                guard let not = notification, let (connection, peerID) = not.object as? (Connection, PeerID?) else {
-                    return
-                }
-                return handler(connection, peerID)
-            }
-        case .openedStream(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.OpenedStream) {
-                notification in
-                guard let not = notification, let stream = not.object as? LibP2PCore.Stream else {
-                    //guard let not = notification, let proto = not.object as? String else {
-                    return
-                }
-                return handler(stream)
-            }
-        case .closedStream(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.ClosedStream) {
-                notification in
-                guard let not = notification, let stream = not.object as? LibP2PCore.Stream else {
-                    //guard let not = notification, let proto = not.object as? String else {
-                    return
-                }
-                return handler(stream)
-            }
-        case .remotePeer(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.RemotePeer) {
-                notification in
-                guard let not = notification, let remotePeer = not.object as? PeerInfo else {
-                    return
-                }
-                return handler(remotePeer)
-            }
-        case .upgraded(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.Upgraded) {
-                notification in
-                guard let not = notification, let connection = not.object as? Connection else {
-                    return
-                }
-                return handler(connection)
-            }
-        case .identifiedPeer(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.IdentifiedPeer) {
-                notification in
-                guard let not = notification, let identifiedPeer = not.object as? IdentifiedPeer else {
-                    return
-                }
-                return handler(identifiedPeer)
-            }
-        case .peerDiscovered(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.PeerDiscovered) {
-                notification in
-                guard let not = notification, let peerInfo = not.object as? PeerInfo else {
-                    return
-                }
-                return handler(peerInfo)
-            }
+        let kind = event.kind
 
-        /// What used to be internal
-        case .listen(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.Listen) { notification in
-                guard let not = notification, let obj = not.object as? (String, Multiaddr) else {
-                    return
-                }
-                return handler(obj.0, obj.1)
-            }
-        case .listenClosed(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.ListenClose) {
-                notification in
-                guard let not = notification, let obj = not.object as? (String, Multiaddr) else {
-                    return
-                }
-                return handler(obj.0, obj.1)
-            }
+        // Snapshot the interested continuations under the lock, then release it before yielding.
+        // Yielding is non-blocking (bounded buffer per subscriber), so no subscriber — however slow —
+        // can stall the poster or another subscriber.
+        let continuations = self.registry.withLockedValue { registry in
+            registry.continuations[kind].map { Array($0.values) } ?? []
+        }
 
-        case .remotePeerProtocolChange(let handler):
-            self.subscribe(register, name: SwiftEventBus.Event.RemotePeerProtocolChange) { notification in
-                guard let not = notification, let protocolChange = not.object as? LibP2P.RemotePeerProtocolChange else {
-                    return
-                }
-                return handler(protocolChange)
-            }
+        for continuation in continuations {
+            continuation.yield(event)
         }
     }
 
-    /// Registers a `NotificationCenter` observer for `name`, siloed by this bus's `instanceID`.
+    // MARK: - Callback subscriptions
+
+    /// Registers a callback for `event`, keyed off `register`'s identity. Remove it later with
+    /// ``unregister(_:)`` (passing the same `register` object).
     ///
-    /// - Important: We register with `queue: nil`, so the observer block runs **synchronously on the
-    ///   posting thread**. We deliberately avoid `SwiftEventBus.onBackgroundThread`: its background
-    ///   `OperationQueue`-based delivery does not fire on Swift 6.3 / swift-corelibs-foundation (the
-    ///   observer block is never scheduled), which silently disabled the entire `EventBus` on Linux 6.3.
-    ///   Synchronous, `queue: nil` delivery works on every platform; existing handlers already hop to their
-    ///   own event loops, so being invoked synchronously on the poster's thread is safe.
-    private func subscribe(
-        _ register: AnyObject,
-        name: String,
-        _ handler: @escaping (Notification?) -> Void
-    ) {
-        SwiftEventBus.on(register, name: name + instanceID, sender: nil, queue: nil, handler: handler)
+    /// The callback is delivered on a private drain `Task` — one per subscription — so it runs in order
+    /// but never on the posting thread, and a slow callback only backs up its own bounded buffer.
+    public func on(_ register: AnyObject, event: EventHandler) {
+        let owner = ObjectIdentifier(register)
+        let kinds: Set<Kind> = [event.kind]
+        let (id, stream) = self.openStream(kinds: kinds)
+
+        let task = Task {
+            for await emitter in stream {
+                EventBus.invoke(event, with: emitter)
+            }
+        }
+
+        self.registry.withLockedValue { registry in
+            registry.callbackTokens[owner, default: []].append(CallbackToken(id: id, kinds: kinds, task: task))
+        }
     }
 
-    //    internal func on(_ register:AnyObject, event:_EventHandler) {
-    //        switch event {
-    //        case .listen(let handler):
-    //            self.subscribe(register, name: SwiftEventBus.Event.Listen) { notification in
-    //                guard let not = notification, let obj = not.object as? (String, Multiaddr) else {
-    //                    return
-    //                }
-    //                return handler(obj.0, obj.1)
-    //            }
-    //        case .listenClosed(let handler):
-    //            self.subscribe(register, name: SwiftEventBus.Event.ListenClose) { notification in
-    //                guard let not = notification, let obj = not.object as? (String, Multiaddr) else {
-    //                    return
-    //                }
-    //                return handler(obj.0, obj.1)
-    //            }
-    ////        case .identifiedPeer(let handler):
-    ////            self.subscribe(register, name: SwiftEventBus.Event.IdentifiedPeer) { notification in
-    ////                guard let not = notification, let identifiedPeer = not.object as? IdentifiedPeer else {
-    ////                    return
-    ////                }
-    ////                return handler(identifiedPeer)
-    ////            }
-    //        case .remotePeerProtocolChange(let handler):
-    //            self.subscribe(register, name: SwiftEventBus.Event.RemotePeerProtocolChange) { notification in
-    //                guard let not = notification, let protocolChange = not.object as? LibP2P.RemotePeerProtocolChange else {
-    //                    return
-    //                }
-    //                return handler(protocolChange)
-    //            }
-    //        }
-    //    }
+    /// Dispatches a delivered event to the matching typed callback. The subscription only ever receives
+    /// events of its registered kind, so the non-matching cases are unreachable.
+    private static func invoke(_ handler: EventHandler, with emitter: EventEmitter) {
+        switch handler {
+        case .connected(let cb): if case .connected(let c) = emitter { cb(c) }
+        case .disconnected(let cb): if case .disconnected(let c, let p) = emitter { cb(c, p) }
+        case .openedStream(let cb): if case .openedStream(let s) = emitter { cb(s) }
+        case .closedStream(let cb): if case .closedStream(let s) = emitter { cb(s) }
+        case .remotePeer(let cb): if case .remotePeer(let p) = emitter { cb(p) }
+        case .upgraded(let cb): if case .upgraded(let c) = emitter { cb(c) }
+        case .identifiedPeer(let cb): if case .identifiedPeer(let p) = emitter { cb(p) }
+        case .peerDiscovered(let cb): if case .peerDiscovered(let p) = emitter { cb(p) }
+        case .listen(let cb): if case .listen(let s, let ma) = emitter { cb(s, ma) }
+        case .listenClosed(let cb): if case .listenClosed(let s, let ma) = emitter { cb(s, ma) }
+        case .remotePeerProtocolChange(let cb): if case .remotePeerProtocolChange(let change) = emitter { cb(change) }
+        }
+    }
 
+    /// Removes every callback registered under `object`'s identity across all event kinds.
     public func unregister(_ object: AnyObject) {
-        SwiftEventBus.unregister(object)
+        let owner = ObjectIdentifier(object)
+        let tokens = self.registry.withLockedValue { registry in
+            registry.callbackTokens.removeValue(forKey: owner) ?? []
+        }
+        // Cancelling each drain task ends its `for await`, whose stream `onTermination` removes the
+        // continuation from `continuations`.
+        for token in tokens {
+            token.task.cancel()
+        }
+    }
+
+    // MARK: - AsyncStream subscriptions
+
+    /// An `AsyncStream` delivering every event whose ``EventEmitter/kind`` is in `kinds`. The stream
+    /// deregisters itself when the consumer stops iterating or the task is cancelled.
+    public func subscribe(to kinds: Set<Kind>) -> AsyncStream<EventEmitter> {
+        self.openStream(kinds: kinds).stream
+    }
+
+    /// An `AsyncStream` delivering every event, regardless of kind.
+    public func subscribe() -> AsyncStream<EventEmitter> {
+        self.subscribe(to: Set(Kind.allCases))
+    }
+
+    /// Creates a bounded `AsyncStream`, registers its continuation for every kind in `kinds`, and wires
+    /// `onTermination` to remove it. Shared by both the callback and public-stream subscription paths.
+    /// Returns the subscription's token id alongside the stream (the callback path needs the id to key
+    /// its `CallbackToken`; ``subscribe(to:)`` discards it).
+    private func openStream(kinds: Set<Kind>) -> (id: UUID, stream: AsyncStream<EventEmitter>) {
+        let id = UUID()
+        let stream = AsyncStream(EventEmitter.self, bufferingPolicy: .bufferingNewest(Self.streamBufferSize)) {
+            continuation in
+            self.registry.withLockedValue { registry in
+                for kind in kinds {
+                    registry.continuations[kind, default: [:]][id] = continuation
+                }
+            }
+            // Capture `self` weakly: the continuation is retained by the registry (and, for callbacks, by
+            // the drain task), so a strong capture here would form a retain cycle that keeps the bus alive.
+            continuation.onTermination = { [weak self] _ in
+                self?.registry.withLockedValue { registry in
+                    for kind in kinds {
+                        registry.continuations[kind]?[id] = nil
+                        if registry.continuations[kind]?.isEmpty == true {
+                            registry.continuations[kind] = nil
+                        }
+                    }
+                }
+            }
+        }
+        return (id, stream)
     }
 }
 
-public struct IdentifiedPeer {
+extension EventBus {
+    /// Test-only introspection into the live subscription registry: the total number of registered
+    /// continuations (summed across every kind) and the number of distinct callback owners. Used by the
+    /// stress test to assert the registry neither grows with post volume nor leaks subscriptions after
+    /// teardown. `internal`, so it is only reachable via `@testable import`.
+    internal var subscriptionSnapshot: (continuations: Int, callbackOwners: Int) {
+        self.registry.withLockedValue { registry in
+            (
+                registry.continuations.values.reduce(into: 0) { $0 += $1.count },
+                registry.callbackTokens.count
+            )
+        }
+    }
+}
+
+public struct IdentifiedPeer: Sendable {
     public let peer: PeerID
     public let identity: [UInt8]
 
@@ -371,7 +346,7 @@ public struct IdentifiedPeer {
     }
 }
 
-public struct RemotePeerProtocolChange {
+public struct RemotePeerProtocolChange: Sendable {
     public let peer: PeerID
     public let protocols: [SemVerProtocol]
     public let connection: Connection

--- a/Sources/LibP2P/EventBus/EventBus.swift
+++ b/Sources/LibP2P/EventBus/EventBus.swift
@@ -17,10 +17,21 @@ import LibP2PCore
 import NIOConcurrencyHelpers
 
 extension Application.Events.Provider {
+    /// The default `EventBus`, using ``EventBus/defaultBufferSize`` for each subscriber's delivery buffer.
     public static var `default`: Self {
+        .default()
+    }
+
+    /// The default `EventBus` with a configurable per-subscriber delivery buffer.
+    ///
+    /// - Parameter bufferSize: The maximum number of events buffered per subscriber (callback or
+    ///   `AsyncStream`). A slow/abandoned subscriber drops its own oldest events past this bound rather
+    ///   than growing memory or applying backpressure to the poster. Defaults to
+    ///   ``EventBus/defaultBufferSize``.
+    public static func `default`(bufferSize: Int = EventBus.defaultBufferSize) -> Self {
         .init { app in
             app.eventbus.use {
-                EventBus(application: $0)
+                EventBus(application: $0, bufferSize: bufferSize)
             }
         }
     }
@@ -81,7 +92,10 @@ public final class EventBus: Sendable {
     /// Maximum number of buffered events per subscriber (both callback and `AsyncStream`). A slow or
     /// abandoned consumer drops its own oldest events rather than growing memory without bound or
     /// applying backpressure to the poster.
-    private static let streamBufferSize = 64
+    ///
+    /// The default used when none is supplied to ``init(application:bufferSize:)`` or the
+    /// ``Application/Events/Provider/default(bufferSize:)`` provider.
+    public static let defaultBufferSize = 64
 
     /// Bookkeeping for one ``on(_:event:)`` callback subscription, so ``unregister(_:)`` can tear it
     /// down: cancelling `task` ends its drain loop, whose stream `onTermination` removes the
@@ -105,8 +119,12 @@ public final class EventBus: Sendable {
     private let logger: Logger
     private let registry: NIOLockedValueBox<Registry>
 
-    init(application: Application) {
+    /// The maximum number of events buffered per subscriber before the oldest are dropped.
+    private let bufferSize: Int
+
+    init(application: Application, bufferSize: Int = EventBus.defaultBufferSize) {
         self.application = application
+        self.bufferSize = bufferSize
         self.registry = .init(Registry())
 
         var logger = application.logger
@@ -297,7 +315,7 @@ public final class EventBus: Sendable {
     /// its `CallbackToken`; ``subscribe(to:)`` discards it).
     private func openStream(kinds: Set<Kind>) -> (id: UUID, stream: AsyncStream<EventEmitter>) {
         let id = UUID()
-        let stream = AsyncStream(EventEmitter.self, bufferingPolicy: .bufferingNewest(Self.streamBufferSize)) {
+        let stream = AsyncStream(EventEmitter.self, bufferingPolicy: .bufferingNewest(self.bufferSize)) {
             continuation in
             self.registry.withLockedValue { registry in
                 for kind in kinds {

--- a/Sources/LibP2P/LibP2P.swift
+++ b/Sources/LibP2P/LibP2P.swift
@@ -583,16 +583,11 @@ extension Application {
         /// On Verified Remote Peer Subscription
         ///
         /// This is responsible for adding a Verified Remote Peer to our PeerStore
-        self.events.on(self, event: .remotePeer(onRemotePeer))
-
-        /// On Verified Remote Peer Subscription
-        ///
-        /// This is responsible for adding a Verified Remote Peer to our PeerStore
-        func onRemotePeer(_ peer: PeerInfo) {
+        let onRemotePeer: @Sendable (PeerInfo) -> Void = { peer in
             guard peer.peer != self.peerID else { return }
-            logger.debug("Verified Remote Peer")
-            logger.debug("Peer: \(peer.peer.b58String)")
-            logger.debug("Address: \(peer.addresses)")
+            self.logger.debug("Verified Remote Peer")
+            self.logger.debug("Peer: \(peer.peer.b58String)")
+            self.logger.debug("Address: \(peer.addresses)")
 
             let _ = self.peers.add(key: peer.peer, on: nil).flatMap { _ -> EventLoopFuture<Void> in
                 self.logger.debug("Attempting to add known multiaddr to peerstore")
@@ -606,6 +601,7 @@ extension Application {
                 }
             }
         }
+        self.events.on(self, event: .remotePeer(onRemotePeer))
 
         //self.events.on(self, event: .identifiedPeer( onPeerIdentified ))
         //        func onPeerIdentified(_ identifiedPeer:IdentifiedPeer) -> Void {

--- a/Sources/LibP2P/Topology/BasicMulticodecTopology.swift
+++ b/Sources/LibP2P/Topology/BasicMulticodecTopology.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import LibP2PCore
+import NIOConcurrencyHelpers
 
 //public struct TopologyRegistration {
 ////    public enum ProtocolSet {
@@ -50,24 +51,26 @@ import LibP2PCore
 //}
 
 // TODO: Conform to MulticodecTopology
-public class BasicMulticodecTopology {
+public final class BasicMulticodecTopology: Sendable {
 
     private let application: Application
     private let uuid: UUID
 
     public let min: Int
     public let max: Int
-    public var protocols: [SemVerProtocol]
+    public let protocols: [SemVerProtocol]
 
     public let handlers: TopologyHandler
     public var peers: [String: PeerID] {
-        _peers.compactMapValues { conn in
-            conn.remotePeer
+        _peers.withLockedValue { peers in
+            peers.compactMapValues { conn in
+                conn.remotePeer
+            }
         }
     }
 
-    private var _peers: [String: Connection]
-    private var logger: Logger
+    private let _peers: NIOLockedValueBox<[String: Connection]>
+    private let logger: Logger
 
     public required init(application: Application, registration: TopologyRegistration) {
         //public required init(min: Int, max: Int, handlers: TopologyHandler, protocols: [SemVerProtocol]) {
@@ -79,13 +82,14 @@ public class BasicMulticodecTopology {
         self.handlers = registration.handler
         self.protocols = [registration.protocols]
 
-        self._peers = [:]
+        self._peers = .init([:])
 
         //Logger(label: "com.swift.libp2p.basicProtocolTopology[\(UUID().uuidString.prefix(5))]")
-        self.logger = application.logger
-        self.logger[metadataKey: "Topology[\(uuid.uuidString.prefix(5))]"] = .string(
+        var logger = application.logger
+        logger[metadataKey: "Topology[\(uuid.uuidString.prefix(5))]"] = .string(
             "[\(protocols.map { $0.stringValue }.joined(separator: ", "))]"
         )
+        self.logger = logger
 
         // Register for Events
         /// This Event gets triggered when a, fully upgraded, remote peers handled codecs change (usually either due to an Indentify Message or a Identify Delta Message)
@@ -106,8 +110,10 @@ public class BasicMulticodecTopology {
         logger.info("Peer: \(change.peer.b58String)")
         logger.info("Handled Protocols: \(change.protocols.map { $0.stringValue }.joined(separator: ", "))")
 
+        let b58 = change.peer.b58String
+
         // If we're already tracking this peer, ensure that they still support the handled protocol
-        if _peers[change.peer.b58String] != nil {
+        if _peers.withLockedValue({ $0[b58] != nil }) {
             if protocols.matches(any: change.protocols) {
                 //Keep the peer around...
                 logger.info(
@@ -118,17 +124,17 @@ public class BasicMulticodecTopology {
                 logger.info(
                     "Remote Peer no longer supports our interested protocols, proceeding to remove peer from topology"
                 )
-                if let conn = _peers.removeValue(forKey: change.peer.b58String) {
+                if let conn = _peers.withLockedValue({ $0.removeValue(forKey: b58) }) {
                     if let rp = conn.remotePeer { handlers.onDisconnect?(rp) }
                 } else {
-                    logger.warning("Failed to remove Remote Peer \(change.peer.b58String) from our topology list")
+                    logger.warning("Failed to remove Remote Peer \(b58) from our topology list")
                 }
             }
         } else {
             // If we're not already tracking this peer & they support an interested protocol/codec add them to our list and notify our handlers as necessary...
             if protocols.matches(any: change.protocols) {
                 // They support the protocols we're interested in. So lets add them to our tracked peers and notify our handler...
-                _peers[change.peer.b58String] = change.connection
+                _peers.withLockedValue { $0[b58] = change.connection }
                 handlers.onConnect(change.peer, change.connection)
             }
         }
@@ -137,7 +143,7 @@ public class BasicMulticodecTopology {
     private func onDisconnected(_ conn: Connection, peer: PeerID? = nil) {
         /// Loop through our _peers list and remove any instances of this (now disconnected) peer
         if let peer = conn.remotePeer {
-            if let _ = self._peers.removeValue(forKey: peer.b58String) {
+            if _peers.withLockedValue({ $0.removeValue(forKey: peer.b58String) }) != nil {
                 logger.info("Removed Disconnected Peer \(peer.b58String)")
                 handlers.onDisconnect?(peer)
             }
@@ -148,7 +154,7 @@ public class BasicMulticodecTopology {
 
     public func deinitialize() {
         logger.info("BasicMutlicodecTopology::Deinitializing")
-        self._peers.removeAll()
+        self._peers.withLockedValue { $0.removeAll() }
         //SwiftEventBus.unregister(self)
         application.events.unregister(self)
     }

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -655,7 +655,7 @@ extension LibP2PTests {
         @Test("`.default(bufferSize:)` bounds each subscriber's delivery buffer")
         func testConfigurableBufferSize() async throws {
             let bufferSize = 4
-            let configuration:((Application) async throws -> Void) = { app in
+            let configuration: ((Application) async throws -> Void) = { app in
                 app.eventbus.use(.default(bufferSize: bufferSize))
             }
             try await withApp(configure: configuration) { app in

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -40,6 +40,15 @@ extension LibP2PTests {
         /// each test keeps its own instance alive for the duration of the test.
         final class Subscriber {}
 
+        /// A subscription owner that reports its own deallocation. The stress test uses this to prove the bus
+        /// holds no strong reference to registrants (it stores only their `ObjectIdentifier`), so dropping the
+        /// owners deinitializes them promptly.
+        final class TrackedSubscriber {
+            private let onDeinit: @Sendable () -> Void
+            init(onDeinit: @escaping @Sendable () -> Void) { self.onDeinit = onDeinit }
+            deinit { onDeinit() }
+        }
+
         /// Polls `predicate` until it returns `true` or the attempts are exhausted. Returns the final value
         /// of the predicate (so a caller can assert both "eventually true" and "never true").
         static func waitUntil(
@@ -259,6 +268,380 @@ extension LibP2PTests {
                     await ConnectionEventTests.waitUntil { received.withLockedValue { $0.contains(connection.id) } }
                 )
                 _ = (subscriber, connection)
+            }
+        }
+
+        // MARK: - Unregister
+
+        @Test("`unregister` stops further callback delivery to that owner")
+        func testUnregisterStopsDelivery() async throws {
+            try await withApp { app in
+                try await app.startup()
+
+                let subscriber = Subscriber()
+                let count = NIOLockedValueBox<Int>(0)
+                app.events.on(
+                    subscriber,
+                    event: .connected { _ in
+                        count.withLockedValue { $0 += 1 }
+                    }
+                )
+
+                // First post is delivered.
+                app.events.post(.connected(DummyConnection(direction: .outbound)))
+                #expect(await ConnectionEventTests.waitUntil { count.withLockedValue { $0 == 1 } })
+
+                // After unregistering, subsequent posts must not reach the handler.
+                app.events.unregister(subscriber)
+                app.events.post(.connected(DummyConnection(direction: .outbound)))
+
+                let deliveredAgain = await ConnectionEventTests.waitUntil(
+                    { count.withLockedValue { $0 > 1 } },
+                    attempts: 20
+                )
+                #expect(deliveredAgain == false)
+                #expect(count.withLockedValue { $0 } == 1)
+                _ = subscriber
+            }
+        }
+
+        // MARK: - AsyncStream subscriptions
+
+        @Test("`subscribe(to:)` delivers matching events and terminates on cancellation")
+        func testAsyncStreamDeliversAndTerminates() async throws {
+            try await withApp { app in
+                try await app.startup()
+
+                let received = NIOLockedValueBox<[UUID]>([])
+                let terminated = NIOLockedValueBox<Bool>(false)
+                let stream = app.events.subscribe(to: [.connected])
+
+                let task = Task {
+                    for await event in stream {
+                        if case .connected(let connection) = event {
+                            received.withLockedValue { $0.append(connection.id) }
+                        }
+                    }
+                    // The loop only exits once the stream finishes (here, via task cancellation),
+                    // which is what fires the continuation's `onTermination` cleanup.
+                    terminated.withLockedValue { $0 = true }
+                }
+
+                let connection = DummyConnection(direction: .outbound)
+                app.events.post(.connected(connection))
+
+                #expect(await ConnectionEventTests.waitUntil { received.withLockedValue { !$0.isEmpty } })
+                #expect(received.withLockedValue { $0.first } == connection.id)
+
+                task.cancel()
+                await task.value
+                #expect(terminated.withLockedValue { $0 } == true)
+            }
+        }
+
+        @Test("A terminated `subscribe(to:)` stream stops receiving events (the AsyncStream analogue of `unregister`)")
+        func testAsyncStreamStopsDeliveryAfterTermination() async throws {
+            try await withApp { app in
+                try await app.startup()
+
+                let received = NIOLockedValueBox<[UUID]>([])
+                let stream = app.events.subscribe(to: [.connected])
+
+                let task = Task {
+                    for await event in stream {
+                        if case .connected(let connection) = event {
+                            received.withLockedValue { $0.append(connection.id) }
+                        }
+                    }
+                }
+
+                // First post is delivered to the live stream.
+                let first = DummyConnection(direction: .outbound)
+                app.events.post(.connected(first))
+                #expect(await ConnectionEventTests.waitUntil { received.withLockedValue { $0.count == 1 } })
+
+                // Tearing down the consumer fires the continuation's `onTermination`, which removes it from
+                // the bus. Awaiting the task guarantees that cleanup has run before we post again.
+                task.cancel()
+                await task.value
+
+                app.events.post(.connected(DummyConnection(direction: .outbound)))
+
+                let deliveredAgain = await ConnectionEventTests.waitUntil(
+                    { received.withLockedValue { $0.count > 1 } },
+                    attempts: 20
+                )
+                #expect(deliveredAgain == false)
+                #expect(received.withLockedValue { $0 } == [first.id])
+            }
+        }
+
+        // MARK: - Per-instance isolation
+
+        /// A `NotificationCenter`-backed bus keys subscriptions off a process-global registry, so two nodes
+        /// listening for the same event name would cross-receive each other's posts unless carefully siloed.
+        /// The native `EventBus` gives each `Application` its own registry, so this is structurally impossible —
+        /// this regression test locks that guarantee in.
+        @Test("Two Applications subscribed to the same event do not receive each other's posts")
+        func testEventsAreIsolatedPerApplication() async throws {
+            try await withApp { appA in
+                try await withApp { appB in
+                    try await appA.startup()
+                    try await appB.startup()
+
+                    let subscriberA = Subscriber()
+                    let subscriberB = Subscriber()
+                    let receivedA = NIOLockedValueBox<[UUID]>([])
+                    let receivedB = NIOLockedValueBox<[UUID]>([])
+
+                    appA.events.on(
+                        subscriberA,
+                        event: .connected { connection in
+                            receivedA.withLockedValue { $0.append(connection.id) }
+                        }
+                    )
+                    appB.events.on(
+                        subscriberB,
+                        event: .connected { connection in
+                            receivedB.withLockedValue { $0.append(connection.id) }
+                        }
+                    )
+
+                    // Post on A only.
+                    let connectionA = DummyConnection(direction: .outbound)
+                    appA.events.post(.connected(connectionA))
+
+                    #expect(await ConnectionEventTests.waitUntil { receivedA.withLockedValue { !$0.isEmpty } })
+                    #expect(receivedA.withLockedValue { $0 } == [connectionA.id])
+                    // B must not have seen A's event.
+                    let leakedToB = await ConnectionEventTests.waitUntil(
+                        { receivedB.withLockedValue { !$0.isEmpty } },
+                        attempts: 20
+                    )
+                    #expect(leakedToB == false)
+
+                    // Now post on B only and assert the mirror image.
+                    let connectionB = DummyConnection(direction: .inbound)
+                    appB.events.post(.connected(connectionB))
+
+                    #expect(await ConnectionEventTests.waitUntil { receivedB.withLockedValue { !$0.isEmpty } })
+                    #expect(receivedB.withLockedValue { $0 } == [connectionB.id])
+                    // A must still only have its own single event.
+                    #expect(receivedA.withLockedValue { $0 } == [connectionA.id])
+
+                    _ = (subscriberA, subscriberB)
+                }
+            }
+        }
+
+        // MARK: - Slow / non-responsive consumer isolation
+
+        /// Every subscriber — callback or `AsyncStream` — is delivered through its own bounded, non-blocking
+        /// buffer, and `post` only ever `yield`s onto them. So a subscriber that is wedged (a callback blocked
+        /// on its drain task) or entirely non-responsive (a stream that is never drained) can neither stall
+        /// `post` nor delay any other subscriber. This drives a callback subscriber that stays blocked on its
+        /// very first event and asserts the responsive callback- and stream-subscribers still receive every
+        /// event meanwhile — then releases the slow one and confirms its events were buffered, not dropped.
+        @Test("A slow / non-responsive consumer does not block other subscribers")
+        func testSlowConsumerDoesNotBlockOthers() async throws {
+            try await withApp { app in
+                try await app.startup()
+
+                // A non-responsive AsyncStream consumer: subscribed but never iterated. Its bounded buffer just
+                // fills and drops its own oldest events; yielding to it never blocks `post`.
+                let stalledStream = app.events.subscribe(to: [.connected])
+
+                // A deliberately slow callback subscriber: its drain task blocks on the very first event until
+                // the test explicitly releases it, modelling a wedged/unresponsive handler.
+                let releaseSlow = NIOLockedValueBox<Bool>(false)
+                let slowCount = NIOLockedValueBox<Int>(0)
+                let slowSubscriber = Subscriber()
+                app.events.on(
+                    slowSubscriber,
+                    event: .connected { _ in
+                        while releaseSlow.withLockedValue({ $0 }) == false {
+                            usleep(1_000)
+                        }
+                        slowCount.withLockedValue { $0 += 1 }
+                    }
+                )
+
+                // A responsive callback subscriber.
+                let subscriber = Subscriber()
+                let callbackCount = NIOLockedValueBox<Int>(0)
+                app.events.on(
+                    subscriber,
+                    event: .connected { _ in
+                        callbackCount.withLockedValue { $0 += 1 }
+                    }
+                )
+
+                // A responsive stream subscriber that drains promptly.
+                let streamCount = NIOLockedValueBox<Int>(0)
+                let liveStream = app.events.subscribe(to: [.connected])
+                let drain = Task {
+                    for await _ in liveStream {
+                        streamCount.withLockedValue { $0 += 1 }
+                    }
+                }
+
+                // Post fewer events than the per-subscriber buffer (64) so no responsive subscriber can drop.
+                let count = 50
+                for _ in 0..<count {
+                    app.events.post(.connected(DummyConnection(direction: .outbound)))
+                }
+
+                // The responsive subscribers receive every event even though the slow subscriber is still wedged
+                // on its first event — delivery is isolated per subscriber, so neither `post` nor the fast drains
+                // ever wait on the slow one.
+                #expect(await ConnectionEventTests.waitUntil { callbackCount.withLockedValue { $0 == count } })
+                #expect(await ConnectionEventTests.waitUntil { streamCount.withLockedValue { $0 == count } })
+                // ...and the slow subscriber genuinely made no progress while blocked.
+                #expect(slowCount.withLockedValue { $0 } == 0)
+
+                // Release it and confirm it drains all buffered events — proving they were queued for it, not
+                // dropped (count < buffer), and that it never gated anyone else.
+                releaseSlow.withLockedValue { $0 = true }
+                #expect(await ConnectionEventTests.waitUntil { slowCount.withLockedValue { $0 == count } })
+
+                drain.cancel()
+                await drain.value
+                _ = (subscriber, slowSubscriber, stalledStream)
+            }
+        }
+
+        // MARK: - Stress / stability
+
+        /// Hammers the bus with many subscribers and a high, concurrent post volume for ~3 seconds, then tears
+        /// everything down. It asserts three stability properties:
+        ///   * **Bounded memory** — the bus keeps no per-event state: its live subscription count stays exactly
+        ///     equal to the number registered, no matter how many events are posted (delivery buffers are
+        ///     separately bounded by `.bufferingNewest(64)`, so a subscriber can't grow unbounded either).
+        ///   * **Fan-out correctness** — every responsive subscriber (callback and stream) receives events.
+        ///   * **Clean teardown** — after `unregister`/cancel the registry drains to zero continuations and zero
+        ///     callback owners, and dropping the owner objects deinitializes them (the bus holds no strong refs).
+        @Test("Stress: many subscribers + heavy post volume stays bounded and tears down cleanly", .timeLimit(.minutes(1)))
+        func testHighVolumeStaysBoundedAndDeinitializes() async throws {
+            try await withApp { app in
+                try await app.startup()
+
+                let callbackSubscribers = 100
+                let fastStreamSubscribers = 100
+                let slowStreamSubscribers = 10
+
+                // The running node's own subsystems (connection manager, topology, identify, root handlers)
+                // already hold subscriptions, so capture that baseline and assert our deltas against it.
+                let baseline = app.events.subscriptionSnapshot
+                let expectedContinuations =
+                    baseline.continuations + callbackSubscribers + fastStreamSubscribers + slowStreamSubscribers
+                let expectedCallbackOwners = baseline.callbackOwners + callbackSubscribers
+
+                // Track deinitialization of the callback owners.
+                let deinitCount = NIOLockedValueBox<Int>(0)
+                var owners: [TrackedSubscriber] = []
+                let callbackCounts = (0..<callbackSubscribers).map { _ in NIOLockedValueBox<Int>(0) }
+
+                for index in 0..<callbackSubscribers {
+                    let counter = callbackCounts[index]
+                    let owner = TrackedSubscriber { deinitCount.withLockedValue { $0 += 1 } }
+                    owners.append(owner)
+                    app.events.on(
+                        owner,
+                        event: .connected { _ in
+                            counter.withLockedValue { $0 += 1 }
+                        }
+                    )
+                }
+
+                // Fast stream subscribers drain promptly; slow ones sleep per event so their bounded buffers
+                // fill and drop under load — exercising the memory bound rather than blocking anyone.
+                let fastStreamCounts = (0..<fastStreamSubscribers).map { _ in NIOLockedValueBox<Int>(0) }
+                let slowStreamCounts = (0..<slowStreamSubscribers).map { _ in NIOLockedValueBox<Int>(0) }
+                var streamTasks: [Task<Void, Never>] = []
+
+                for index in 0..<fastStreamSubscribers {
+                    let counter = fastStreamCounts[index]
+                    let stream = app.events.subscribe(to: [.connected])
+                    streamTasks.append(
+                        Task {
+                            for await _ in stream { counter.withLockedValue { $0 += 1 } }
+                        }
+                    )
+                }
+                for index in 0..<slowStreamSubscribers {
+                    let counter = slowStreamCounts[index]
+                    let stream = app.events.subscribe(to: [.connected])
+                    streamTasks.append(
+                        Task {
+                            for await _ in stream {
+                                counter.withLockedValue { $0 += 1 }
+                                try? await Task.sleep(for: .milliseconds(5))
+                            }
+                        }
+                    )
+                }
+
+                // Registry reflects exactly what we registered.
+                #expect(app.events.subscriptionSnapshot.continuations == expectedContinuations)
+                #expect(app.events.subscriptionSnapshot.callbackOwners == expectedCallbackOwners)
+
+                // Fire a high, concurrent post volume for ~3 seconds.
+                let posted = NIOLockedValueBox<Int>(0)
+                await withTaskGroup(of: Int.self) { group in
+                    for _ in 0..<4 {
+                        group.addTask {
+                            let connection = DummyConnection(direction: .outbound)
+                            let deadline = Date().addingTimeInterval(3.0)
+                            var local = 0
+                            while Date() < deadline {
+                                app.events.post(.connected(connection))
+                                local += 1
+                                // Yield periodically so the drain tasks get scheduled alongside the posters.
+                                if local % 256 == 0 { await Task.yield() }
+                            }
+                            return local
+                        }
+                    }
+                    for await local in group { posted.withLockedValue { $0 += local } }
+                }
+
+                let totalPosted = posted.withLockedValue { $0 }
+                #expect(totalPosted > 1_000)
+
+                // Bounded memory: even after tens of thousands of posts, the bus holds no extra state — the
+                // subscription count is unchanged.
+                #expect(app.events.subscriptionSnapshot.continuations == expectedContinuations)
+                #expect(app.events.subscriptionSnapshot.callbackOwners == expectedCallbackOwners)
+
+                // Let any buffered events drain, then assert fan-out reached every responsive subscriber.
+                let allCallbacksGotSomething = await ConnectionEventTests.waitUntil {
+                    callbackCounts.allSatisfy { $0.withLockedValue { $0 > 0 } }
+                }
+                #expect(allCallbacksGotSomething)
+                let allFastStreamsGotSomething = await ConnectionEventTests.waitUntil {
+                    fastStreamCounts.allSatisfy { $0.withLockedValue { $0 > 0 } }
+                }
+                #expect(allFastStreamsGotSomething)
+                #expect(slowStreamCounts.allSatisfy { $0.withLockedValue { $0 > 0 } })
+
+                // Tear everything down.
+                for owner in owners { app.events.unregister(owner) }
+                for task in streamTasks { task.cancel() }
+
+                // `unregister` removes callback owners synchronously; continuation removal happens as each
+                // cancelled drain task ends, so poll until the registry is fully empty.
+                let drained = await ConnectionEventTests.waitUntil {
+                    app.events.subscriptionSnapshot.continuations == baseline.continuations
+                }
+                #expect(drained)
+                #expect(app.events.subscriptionSnapshot.callbackOwners == baseline.callbackOwners)
+
+                // The bus never retained the owners (only their `ObjectIdentifier`), so dropping our references
+                // deinitializes all of them.
+                owners.removeAll()
+                #expect(deinitCount.withLockedValue { $0 } == callbackSubscribers)
+
+                for task in streamTasks { await task.value }
             }
         }
     }

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -644,5 +644,38 @@ extension LibP2PTests {
                 for task in streamTasks { await task.value }
             }
         }
+
+        // MARK: - Configurable buffer size
+
+        /// The `.default(bufferSize:)` provider wires a custom per-subscriber buffer bound into the bus. A
+        /// subscriber that doesn't drain while events pile up should retain only the newest `bufferSize`.
+        @Test("`.default(bufferSize:)` bounds each subscriber's delivery buffer")
+        func testConfigurableBufferSize() async throws {
+            let bufferSize = 4
+            try await withApp(configure: { app in
+                app.eventbus.use(.default(bufferSize: bufferSize))
+            }) { app in
+                try await app.startup()
+
+                // Register the subscriber, then post far more than the buffer WITHOUT draining, so the stream
+                // buffers as it goes and keeps only the newest `bufferSize` events.
+                let stream = app.events.subscribe(to: [.connected])
+                for _ in 0..<50 {
+                    app.events.post(.connected(DummyConnection(direction: .outbound)))
+                }
+
+                // Now drain: only the retained (newest `bufferSize`) events should arrive.
+                let received = NIOLockedValueBox<Int>(0)
+                let task = Task {
+                    for await _ in stream { received.withLockedValue { $0 += 1 } }
+                }
+                // Give the drain a moment to consume everything buffered, then stop it.
+                try await Task.sleep(for: .milliseconds(200))
+                task.cancel()
+                await task.value
+
+                #expect(received.withLockedValue { $0 } == bufferSize)
+            }
+        }
     }
 }

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -520,7 +520,10 @@ extension LibP2PTests {
         ///   * **Fan-out correctness** — every responsive subscriber (callback and stream) receives events.
         ///   * **Clean teardown** — after `unregister`/cancel the registry drains to zero continuations and zero
         ///     callback owners, and dropping the owner objects deinitializes them (the bus holds no strong refs).
-        @Test("Stress: many subscribers + heavy post volume stays bounded and tears down cleanly", .timeLimit(.minutes(1)))
+        @Test(
+            "Stress: many subscribers + heavy post volume stays bounded and tears down cleanly",
+            .timeLimit(.minutes(1))
+        )
         func testHighVolumeStaysBoundedAndDeinitializes() async throws {
             try await withApp { app in
                 try await app.startup()

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -655,9 +655,10 @@ extension LibP2PTests {
         @Test("`.default(bufferSize:)` bounds each subscriber's delivery buffer")
         func testConfigurableBufferSize() async throws {
             let bufferSize = 4
-            try await withApp(configure: { app in
+            let configuration:((Application) async throws -> Void) = { app in
                 app.eventbus.use(.default(bufferSize: bufferSize))
-            }) { app in
+            }
+            try await withApp(configure: configuration) { app in
                 try await app.startup()
 
                 // Register the subscriber, then post far more than the buffer WITHOUT draining, so the stream


### PR DESCRIPTION
### What?
This PR introduces a new EventBus that uses buffered AsyncStreams to deliver events to subscribers.

### Changes
- Rebuilt EventBus based on AsyncStreams 
- Preserved old `@escaping` callback api and introduced new `for await in` api
- The EventBus delivers events to subscribers asynchronously, without waiting on subscribers
- Each subscriber gets allocated a buffered AsyncStream that stores the most recent 64 (default buffer size) post events. When this buffer fills, the oldest events are dropped, meaning subscribers **WILL** lose event notifications if they're slow to process events. Therefore it's crucial that subscribers don't perform long running, computation heavy tasks on their subscribed callbacks, they should instead note the change and queue any work to be done in a separate task.

### API
```swift
// Existing callback style
let count = NIOLockedValueBox<Int>(0)
app.events.on(
    subscriber, // some retained object 
    event: .connected { _ in
        count.withLockedValue { $0 += 1 }
    }
)

// New async stream style
let stream = app.events.subscribe(to: [.connected])
let received = NIOLockedValueBox<[UUID]>([])
for await event in stream {
    if case .connected(let connection) = event {
        received.withLockedValue { $0.append(connection.id) }
    }
}
```

### Why
- Removes the SwiftEventBus dependency
- No longer rely on NotificationCenter 
- Modern swift concurrency approach