### PR TITLE
Connection Closing

### DIFF
--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -95,17 +95,20 @@ extension Application {
         let application: Application
 
         var storage: Storage {
+            // Prefer the real storage whenever it still exists — even after
+            // `isShuttingDown` has been set. This lets teardown itself (notably
+            // `closeAllConnections()`) reach the *real* ConnectionManager to drain
+            // and reject connections, instead of a vacuous throwaway. We only fall
+            // back once `storage.clear()` has actually removed our key: at that
+            // point `isShuttingDown` lets stranded event-loop callbacks racing the
+            // teardown finish vacuously instead of tripping the `fatalError`.
+            if let storage = self.application.storage[Key.self] {
+                return storage
+            }
             if self.application.isShuttingDown {
-                // Race window: this Application has begun teardown.
-                // Returning a fresh empty `Storage` lets stranded
-                // event-loop callbacks finish vacuously instead of
-                // trapping at the `fatalError` below.
                 return Storage()
             }
-            guard let storage = self.application.storage[Key.self] else {
-                fatalError("ConnectionManager not initialized. Configure with app.connectionManager.initialize()")
-            }
-            return storage
+            fatalError("ConnectionManager not initialized. Configure with app.connectionManager.initialize()")
         }
 
         public func generateConnection(

--- a/Sources/LibP2P/LibP2P.swift
+++ b/Sources/LibP2P/LibP2P.swift
@@ -467,22 +467,26 @@ public final class Application: Sendable {
     )
     public func shutdown() {
         assert(!self.didShutdown, "Application has already shut down")
-        // Flip `isShuttingDown` *before* touching any storage so
-        // stranded event-loop callbacks fall through the defensive
-        // checks in the post-shutdown storage accessors instead of
-        // tripping `fatalError("X not initialized")`. Set early and
-        // never cleared — distinct from `didShutdown`, which only
-        // flips once shutdown has fully completed.
-        self._isShuttingDown.withLockedValue { $0 = true }
         self.logger.debug("Application shutting down")
+
+        // Signal shutdown up front, before draining anything, so no subsystem that
+        // consults these flags keeps operating while we tear down. Set early and
+        // never cleared — distinct from `didShutdown`, which only flips once
+        // shutdown has fully completed.
+        self._isShuttingDown.withLockedValue { $0 = true }
         self._isRunning.withLockedValue { $0 = false }
+
+        // Close all live connections BEFORE the lifecycle handlers (the servers)
+        // shut down: quiescing a TCP server waits for its accepted child channels to
+        // close, so leaving them open here would block server shutdown until its
+        // `shutdownTimeout` elapses. `closeAllConnections()` also flips the manager
+        // to its shutting-down state, so any racing dial/accept is rejected.
+        self.logger.debug("Attempting to close all connections")
+        try? self.connections.closeAllConnections().wait()
 
         self.logger.trace("Shutting down providers")
         for handler in self.lifecycle.handlers.reversed() { handler.shutdown(self) }
         self.lifecycle.handlers = []
-
-        self.logger.debug("Attempting to close all connections")
-        try? self.connections.closeAllConnections().wait()
 
         self.logger.trace("Shutting Down All Registered Services")
         self.storage.shutdown(last: Events.Key.self)
@@ -511,18 +515,21 @@ public final class Application: Sendable {
 
     public func asyncShutdown() async throws {
         assert(!self.didShutdown, "Application has already shut down")
-        // See the matching block in the sync `shutdown()` above.
-        self._isShuttingDown.withLockedValue { $0 = true }
         self.logger.debug("Application shutting down")
+
+        // Signal shutdown up front, then drain — see the matching block in the sync
+        // `shutdown()` above for the full rationale
+        self._isShuttingDown.withLockedValue { $0 = true }
+        self._isRunning.withLockedValue { $0 = false }
+
+        self.logger.debug("Attempting to close all connections")
+        try? await self.connections.closeAllConnections().get()
 
         self.logger.trace("Shutting down providers")
         for handler in self.lifecycle.handlers.reversed() {
             await handler.shutdownAsync(self)
         }
         self.lifecycle.handlers = []
-
-        self.logger.debug("Attempting to close all connections")
-        try? await self.connections.closeAllConnections().get()
 
         self.logger.trace("Shutting Down All Registered Services")
         await self.storage.asyncShutdown(last: Events.Key.self)

--- a/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
+++ b/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
@@ -301,7 +301,13 @@ private final class TCPServerConnection: Sendable {
 
                 // Add the new inbound connection to our ConnectionManager
                 return application.connections.addConnection(conn, on: nil).flatMap {
-                    channel.pipeline.addHandler(BackPressureHandler(), position: .first).flatMap {
+                    // `QuiesceOnShutdownHandler` sits at the head so that when the
+                    // server begins quiescing it closes this accepted channel — see
+                    // its doc comment. `BackPressureHandler` follows it.
+                    channel.pipeline.addHandlers(
+                        [QuiesceOnShutdownHandler(), BackPressureHandler()],
+                        position: .first
+                    ).flatMap {
                         // Initialize the new inbound channel
                         conn.initializeChannel()
                     }
@@ -374,5 +380,26 @@ final class TCPServerErrorHandler: ChannelInboundHandler {
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.error("Unhandled TCP server error: \(error)")
         context.close(mode: .output, promise: nil)
+    }
+}
+
+/// Closes an accepted connection channel when the server begins to quiesce.
+///
+/// `ServerQuiescingHelper` (used by ``TCPServer`` to shut down gracefully) stops accepting new
+/// connections and then waits for every already-accepted child channel to close before it completes.
+/// The libp2p connection pipeline (security → muxer → …) doesn't react to `ChannelShouldQuiesceEvent`
+/// on the parent channel on its own, so without this handler an open connection would keep the
+/// quiesce blocked until the server's `shutdownTimeout` elapses (surfacing as `serverStopTookTooLong`).
+/// Installing this at the head of each accepted channel makes graceful server shutdown prompt,
+/// independent of whether the connection manager also closed the connection.
+final class QuiesceOnShutdownHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+    typealias InboundOut = ByteBuffer
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if event is ChannelShouldQuiesceEvent {
+            context.close(mode: .all, promise: nil)
+        }
+        context.fireUserInboundEventTriggered(event)
     }
 }

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -260,8 +260,9 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
 
-                // Close the channel and run the loop so the connection's close-future handler fires and posts.
-                try await channel.close().get()
+                // Close the channel and run the loop so the connection's close-future handler fires and posts
+                // `disconnected`.
+                channel.close(promise: nil)
                 loop.run()
 
                 #expect(

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -182,8 +182,11 @@ extension LibP2PTests {
                     }
                 )
 
+                // Use a `NIOAsyncTestingChannel` (thread-safe loop) rather than an `EmbeddedChannel`: the
+                // stream is posted onto the running app's `EventBus` and is retained/torn down on background
+                // delivery threads, which would touch a single-thread-affine `EmbeddedEventLoop` off-thread.
                 let stream = MockStream(
-                    channel: EmbeddedChannel(),
+                    channel: NIOAsyncTestingChannel(),
                     mode: .initiator,
                     id: 42,
                     name: "42",
@@ -250,8 +253,16 @@ extension LibP2PTests {
                     }
                 )
 
-                let loop = EmbeddedEventLoop()
-                let channel = EmbeddedChannel(loop: loop)
+                // Back the connection with a `NIOAsyncTestingChannel` rather than an `EmbeddedChannel`. Both
+                // are in-memory test channels, but `EmbeddedChannel`'s `EmbeddedEventLoop` is single-thread
+                // affine: it asserts ("EmbeddedEventLoop is not thread-safe") the moment it is touched from any
+                // thread other than the one that created it. Once we post this real connection onto the running
+                // app's `EventBus`, the connection is retained by the delivered `.disconnected` event and handled
+                // on background delivery threads; its eventual `deinit` also fails its event-loop-bound
+                // `securedPromise`/`muxedPromise` from whichever thread releases it. Every one of those is an
+                // off-thread touch of the loop. `NIOAsyncTestingChannel`'s `NIOAsyncTestingEventLoop` is
+                // thread-safe (lock-guarded), so it tolerates all of that without tripping the misuse assertion.
+                let channel = NIOAsyncTestingChannel()
                 let connection = BasicConnectionLight(
                     application: app,
                     channel: channel,
@@ -260,10 +271,9 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
 
-                // Close the channel and run the loop so the connection's close-future handler fires and posts
-                // `disconnected`.
-                channel.close(promise: nil)
-                loop.run()
+                // Close the channel so the connection's close-future handler fires and posts `disconnected`.
+                // `finish()` closes the channel and drives the testing loop to completion, all thread-safely.
+                _ = try await channel.finish()
 
                 #expect(
                     await ConnectionEventTests.waitUntil { received.withLockedValue { $0.contains(connection.id) } }

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -73,8 +73,7 @@ extension LibP2PTests {
         @Test("Closing the underlying channel drives connection teardown")
         func testConnectionTeardownOnChannelClose() async throws {
             try await withApp { app in
-                let loop = EmbeddedEventLoop()
-                let channel = EmbeddedChannel(loop: loop)
+                let channel = NIOAsyncTestingChannel()
                 let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
                 let connection = BasicConnectionLight(
@@ -85,10 +84,12 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
 
-                // Closing the channel schedules its close-future callback on the embedded loop; run the
-                // loop to let the connection's teardown handler fire.
-                try await channel.close().get()
-                loop.run()
+                // Close the channel so the connection's teardown handler fires. `NIOAsyncTestingChannel` is
+                // backed by a thread-safe `NIOAsyncTestingEventLoop`, so the connection's event-loop-bound
+                // promises can be safely failed from its `deinit` on whatever thread releases it — unlike an
+                // `EmbeddedEventLoop`, which asserts when touched off its creating thread. `finish()` closes
+                // the channel and drives the loop to completion.
+                _ = try await channel.finish()
 
                 #expect(connection.status == .closed)
                 #expect(connection.muxer == nil)


### PR DESCRIPTION
### What?
- Better connection closing with `QuiesceOnShutdownHandler` added to our `TCPServer`. And hopefully better shutdown logic, calling closeAllConnections on app before issuing the shutdown notification to our providers (aka TCPServer). 
- Using NIOAsyncTestingChannel instead of EmbeddedChannel to prevent NIO thread-safety errors