### PR TITLE
Concurrent Connections

### DIFF
--- a/Sources/LibP2P/Clients/Client+Utils.swift
+++ b/Sources/LibP2P/Clients/Client+Utils.swift
@@ -93,10 +93,15 @@ extension Application {
                         return el.makeFailedFuture(Errors.noTransportForMultiaddr(ma))
                     }
                     self.logger.trace("Found Transport for dialing peer \(transport)")
-                    return transport.dial(address: ma).flatMap { connection -> EventLoopFuture<Void> in
-                        guard let conn = connection as? AppConnection else {
-                            return connection.channel.eventLoop.makeFailedFuture(Errors.noTransportForMultiaddr(ma))
+                    /// Coalesce concurrent cold dials to this address onto a single connection.
+                    return self.connectionManager.dial(to: ma) {
+                        transport.dial(address: ma).flatMapThrowing { connection -> AppConnection in
+                            guard let conn = connection as? AppConnection else {
+                                throw Errors.noTransportForMultiaddr(ma)
+                            }
+                            return conn
                         }
+                    }.flatMap { conn -> EventLoopFuture<Void> in
                         self.logger.trace("Asking Connection to open a new stream for `\(proto)`")
                         conn.newStream(
                             forProtocol: proto,
@@ -104,7 +109,7 @@ extension Application {
                             andMiddleware: middleware,
                             closure: closure
                         )
-                        return connection.channel.eventLoop.makeSucceededVoidFuture()
+                        return conn.channel.eventLoop.makeSucceededVoidFuture()
                     }
 
                 }
@@ -185,13 +190,18 @@ extension Application {
                         return self.eventLoopGroup.any().makeFailedFuture(Errors.noTransportForMultiaddr(ma))
                     }
                     self.logger.trace("Found Transport for dialing peer \(transport)")
-                    return transport.dial(address: ma).flatMap { connection -> EventLoopFuture<Void> in
-                        guard let conn = connection as? AppConnection else {
-                            return connection.channel.eventLoop.makeFailedFuture(Errors.noTransportForMultiaddr(ma))
+                    /// Coalesce concurrent cold dials to this address onto a single connection.
+                    return self.connectionManager.dial(to: ma) {
+                        transport.dial(address: ma).flatMapThrowing { connection -> AppConnection in
+                            guard let conn = connection as? AppConnection else {
+                                throw Errors.noTransportForMultiaddr(ma)
+                            }
+                            return conn
                         }
+                    }.flatMap { conn -> EventLoopFuture<Void> in
                         self.logger.trace("Asking Connection to open a new stream for `\(proto)`")
                         conn.newStream(forProtocol: proto)
-                        return connection.channel.eventLoop.makeSucceededVoidFuture()
+                        return conn.channel.eventLoop.makeSucceededVoidFuture()
                     }
 
                 }

--- a/Sources/LibP2P/Connections/ARCConnection.swift
+++ b/Sources/LibP2P/Connections/ARCConnection.swift
@@ -136,6 +136,12 @@ public class ARCConnection: AppConnection, @unchecked Sendable {
             self.logger.trace("Channel -> CloseFuture")
             self.stats.status = .closed
 
+            /// Fail any streams that were queued while we were still upgrading. If the channel closed
+            /// before we finished muxing, those streams will never open — surface the failure to their
+            /// callers immediately (this is what fails coalesced cold dials when an upgrade fails)
+            /// rather than leaving each request to hit its own timeout.
+            self.failQueuedStreams(Application.Connections.Errors.connectionUpgradeFailed)
+
             /// Should ensure that we actually connected before posting a disconnect event
             if self.application.isRunning {
                 self.application.events.post(.disconnected(self, self.remotePeer))
@@ -657,6 +663,14 @@ public class ARCConnection: AppConnection, @unchecked Sendable {
         )
 
         self.eventLoop.execute {
+            /// If the connection has already closed (e.g. a coalesced cold dial whose shared
+            /// connection failed to upgrade), fail fast instead of queueing a stream that will never
+            /// open and would otherwise only surface as a timeout.
+            guard self.stats.status != .closed && self.stats.status != .closing else {
+                self.logger.debug("Refusing new `\(proto)` stream — connection is \(self.stats.status)")
+                self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
+                return
+            }
             /// Cancel and clear our idleTimeoutTask if we have one
             self.cancelTimeoutTask()
             /// Ask our muxer to open the stream...
@@ -680,6 +694,34 @@ public class ARCConnection: AppConnection, @unchecked Sendable {
                 self.logger.trace("Adding `\(proto)` to our pendingStreamCache")
                 self.pendingStreamCache.append(pendingStream)
             }
+        }
+    }
+
+    /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
+    /// `newRequest`) fails immediately instead of waiting for a timeout.
+    private func fail(_ stream: StreamCache, with error: Error) {
+        let errorRequest = Request(
+            application: self.application,
+            event: .error(error),
+            streamDirection: .outbound,
+            connection: self,
+            channel: self.channel,
+            logger: self.logger,
+            on: self.channel.eventLoop
+        )
+        let _ = stream.responder.respond(to: errorRequest)
+    }
+
+    /// Fails and clears every stream still waiting to be opened. Invoked when the connection closes
+    /// before it finished upgrading, so any queued (including coalesced cold-dial) requests fail fast.
+    private func failQueuedStreams(_ error: Error) {
+        let queued = self.pendingStreamCache + self.newStreamCache
+        self.pendingStreamCache = []
+        self.newStreamCache = []
+        guard !queued.isEmpty else { return }
+        self.logger.debug("Failing \(queued.count) queued stream(s) due to: \(error)")
+        for stream in queued {
+            self.fail(stream, with: error)
         }
     }
 

--- a/Sources/LibP2P/Connections/BasicConnectionLight.swift
+++ b/Sources/LibP2P/Connections/BasicConnectionLight.swift
@@ -546,9 +546,6 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
         )
 
         self.eventLoop.execute {
-            /// Append a stream event in our stream history array
-            self.streamHistory.append(StreamStateEntry(proto: proto, id: 0, state: .initialized, date: Date()))
-
             /// If the connection has already closed (e.g. a coalesced cold dial whose shared
             /// connection failed to upgrade), fail fast instead of queueing a stream that will never
             /// open and would otherwise only surface as a timeout.
@@ -557,6 +554,9 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
                 self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
                 return
             }
+
+            /// Append a stream event in our stream history array
+            self.streamHistory.append(StreamStateEntry(proto: proto, id: 0, state: .initialized, date: Date()))
 
             /// Ask our muxer to open the stream...
             if self.isMuxed, let mux = self.muxer {

--- a/Sources/LibP2P/Connections/BasicConnectionLight.swift
+++ b/Sources/LibP2P/Connections/BasicConnectionLight.swift
@@ -127,6 +127,12 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
             self.logger.trace("BasicConnectionLight:CloseFuture")
             self.stats.status = .closed
 
+            /// Fail any streams that were queued while we were still upgrading. If the channel closed
+            /// before we finished muxing, those streams will never open — surface the failure to their
+            /// callers immediately (this is what fails coalesced cold dials when an upgrade fails)
+            /// rather than leaving each request to hit its own timeout.
+            self.failQueuedStreams(Application.Connections.Errors.connectionUpgradeFailed)
+
             /// Should ensure that we actually connected before posting a disconnect event
             if self.application.isRunning {
                 self.application.events.post(.disconnected(self, self.remotePeer))
@@ -539,10 +545,19 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
             responder: responder
         )
 
-        /// Append a stream event in our stream history array
-        self.streamHistory.append(StreamStateEntry(proto: proto, id: 0, state: .initialized, date: Date()))
-
         self.eventLoop.execute {
+            /// Append a stream event in our stream history array
+            self.streamHistory.append(StreamStateEntry(proto: proto, id: 0, state: .initialized, date: Date()))
+
+            /// If the connection has already closed (e.g. a coalesced cold dial whose shared
+            /// connection failed to upgrade), fail fast instead of queueing a stream that will never
+            /// open and would otherwise only surface as a timeout.
+            guard self.stats.status != .closed && self.stats.status != .closing else {
+                self.logger.debug("Refusing new `\(proto)` stream — connection is \(self.stats.status)")
+                self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
+                return
+            }
+
             /// Ask our muxer to open the stream...
             if self.isMuxed, let mux = self.muxer {
                 /// Store our responder
@@ -628,6 +643,34 @@ public class BasicConnectionLight: AppConnection, @unchecked Sendable {
             return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) && ($0.direction == direction) })
         } else {
             return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) })
+        }
+    }
+
+    /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
+    /// `newRequest`) fails immediately instead of waiting for a timeout.
+    private func fail(_ stream: StreamCache, with error: Error) {
+        let errorRequest = Request(
+            application: self.application,
+            event: .error(error),
+            streamDirection: .outbound,
+            connection: self,
+            channel: self.channel,
+            logger: self.logger,
+            on: self.channel.eventLoop
+        )
+        let _ = stream.responder.respond(to: errorRequest)
+    }
+
+    /// Fails and clears every stream still waiting to be opened. Invoked when the connection closes
+    /// before it finished upgrading, so any queued (including coalesced cold-dial) requests fail fast.
+    private func failQueuedStreams(_ error: Error) {
+        let queued = self.pendingStreamCache + self.newStreamCache
+        self.pendingStreamCache = []
+        self.newStreamCache = []
+        guard !queued.isEmpty else { return }
+        self.logger.debug("Failing \(queued.count) queued stream(s) due to: \(error)")
+        for stream in queued {
+            self.fail(stream, with: error)
         }
     }
 

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -49,6 +49,10 @@ extension Application {
             /// Thrown when a synchronous, blocking API (e.g. `newStreamSync`) is invoked from the
             /// connection's own event loop, which would deadlock. Use the async/future API instead.
             case cannotBlockEventLoop
+            /// Surfaced to any stream that was queued on a connection which closed before it finished
+            /// upgrading (e.g. a security or muxer negotiation failure). Lets coalesced/queued requests
+            /// fail fast instead of waiting for their own timeouts.
+            case connectionUpgradeFailed
         }
 
         public struct Provider {

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -67,9 +67,15 @@ extension Application {
             let manager: NIOLockedValueBox<ConnectionManager?>
             // Allow the user to specify the Connection class to use (default to ARCConnection)
             let connType: NIOLockedValueBox<AppConnection.Type>
+            /// Tracks cold dials that are currently in flight, keyed by the resolved dial MultiAddress
+            /// (e.g. `/ip4/…/tcp/…/p2p/…`). Because the multiaddress encapsulates both the target
+            /// peer and the network stack, concurrent dials to the same ma coalesce onto a single pending
+            /// connection, while dials to a different ma each get their own independent dial.
+            let dialsInFlight: NIOLockedValueBox<[String: EventLoopFuture<AppConnection>]>
             init() {
                 self.manager = .init(nil)
                 self.connType = .init(ARCConnection.self)
+                self.dialsInFlight = .init([:])
             }
         }
 
@@ -134,6 +140,53 @@ extension Application {
 
         public func setIdleTimeout(_ timeout: TimeAmount) {
             self.storage.manager.withLockedValue { $0?.setIdleTimeout(timeout) }
+        }
+
+        /// Coalesces concurrent cold dials to the same address into a single connection.
+        ///
+        /// If a dial to `ma` is already in flight, the shared, pending dial future is returned so the
+        /// caller can ride the connection currently being established instead of opening a redundant
+        /// one. Once that connection upgrades, every coalesced caller opens its own multiplexed stream
+        /// over it. If no dial is in flight yet, a new one is started via `startDial`, registered, and
+        /// cleared from the registry once it settles. Should the dial fail, every coalesced caller
+        /// observes the same failure.
+        ///
+        /// The registry is keyed by `ma.description`, which encapsulates both the target peer and the
+        /// full network stack, so only dials to the same peer over the same stack coalesce — dials
+        /// to a different stack (a different address) remain independent.
+        func dial(
+            to ma: Multiaddr,
+            startDial: () -> EventLoopFuture<AppConnection>
+        ) -> EventLoopFuture<AppConnection> {
+            let key = ma.description
+            let storage = self.storage
+
+            // Atomically decide whether we're the caller that starts the dial or a caller coalescing
+            // onto an existing one. We reserve our slot with a placeholder promise before releasing
+            // the lock so simultaneous callers can never both start a dial for the same address.
+            let (future, promise): (EventLoopFuture<AppConnection>, EventLoopPromise<AppConnection>?) =
+                storage.dialsInFlight.withLockedValue { dials in
+                    if let existing = dials[key] {
+                        return (existing, nil)
+                    }
+                    let promise = self.application.eventLoopGroup.any().makePromise(of: AppConnection.self)
+                    dials[key] = promise.futureResult
+                    return (promise.futureResult, promise)
+                }
+
+            // Only the reserving caller starts the real dial (outside the lock so `startDial`, which
+            // kicks off async I/O, never runs while the registry is locked).
+            if let promise {
+                startDial().whenComplete { result in
+                    // Drop the entry as soon as the dial settles. By this point a successful connection
+                    // is already registered with the manager, so later cold dials find it via
+                    // `getConnectionsTo` — there's no coverage gap between the two mechanisms.
+                    storage.dialsInFlight.withLockedValue { $0.removeValue(forKey: key) }
+                    promise.completeWith(result)
+                }
+            }
+
+            return future
         }
 
         public func getTotalConnectionCount() -> EventLoopFuture<UInt64> {


### PR DESCRIPTION
### What?
The PR introduces code that cascades multiple concurrent outbound requests to the same multiaddr into a single shared Connection

### Changes
- Added a method to ConnectionManager that registers pending outbound dials an cascades its future to subsequent callers
```swift
func dial(to ma: Multiaddr, startDial: () -> EventLoopFuture<AppConnection>) -> EventLoopFuture<AppConnection>
```
- We route through this new method in our `newStream(to:)` client API's
- We also notify our pending streams of connection closure so they can fail immediately as opposed to timing out

### Addresses
- Closes #5 