### PR TITLE
Write Promises

### DIFF
--- a/Sources/LibP2P/Responder/CommonChannelHandlers/LoggingHandlers.swift
+++ b/Sources/LibP2P/Responder/CommonChannelHandlers/LoggingHandlers.swift
@@ -64,7 +64,7 @@ public final class OutboundLoggerHandler: ChannelOutboundHandler {
         }
         //print("--- Outbound Logger Done ---")
 
-        context.write(wrapOutboundOut(buffer), promise: nil)
+        context.write(wrapOutboundOut(buffer), promise: promise)
     }
 
     // Flush it out. This can make use of gathering writes if multiple buffers are pending

--- a/Sources/LibP2P/Responder/CommonChannelHandlers/NewLineDelimitedHandlers.swift
+++ b/Sources/LibP2P/Responder/CommonChannelHandlers/NewLineDelimitedHandlers.swift
@@ -136,7 +136,7 @@ internal class LineBasedFrameEncoder: ChannelOutboundHandler {
         /// Append a new line to the buffer
         buffer.writeString("\n")
 
-        context.write(wrapOutboundOut(buffer), promise: nil)
+        context.write(wrapOutboundOut(buffer), promise: promise)
     }
 
     // Flush it out. This can make use of gathering writes if multiple buffers are pending

--- a/Sources/LibP2P/Responder/ResponderChannelHandler.swift
+++ b/Sources/LibP2P/Responder/ResponderChannelHandler.swift
@@ -47,10 +47,26 @@ final class ResponderChannelHandler: ChannelInboundHandler, RemovableChannelHand
 
     func serialize(_ response: RawResponse, for request: Request, context: ChannelHandlerContext) {
         guard response.payload.readableBytes > 0 else {
-            self.logger.trace("Dropping Empty Response")
+            // Nothing to write (e.g. `.stayOpen`, or `.close` / `.reset` with an empty payload).
+            // There's no write to wait on, so close immediately if requested.
+            if response.closeAfterWrite {
+                request.shouldClose()
+            } else {
+                self.logger.trace("Dropping Empty Response")
+            }
             return
         }
-        context.write(self.wrapOutboundOut(response), promise: nil)
+
+        guard response.closeAfterWrite else {
+            context.write(self.wrapOutboundOut(response), promise: nil)
+            return
+        }
+
+        // Gate the stream close on the write actually reaching the socket so the final
+        // payload can't be truncated by racing `channel.close()` against an in-flight write.
+        let promise = context.eventLoop.makePromise(of: Void.self)
+        context.write(self.wrapOutboundOut(response), promise: promise)
+        promise.futureResult.whenComplete { _ in request.shouldClose() }
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {

--- a/Sources/LibP2P/Response/Response.swift
+++ b/Sources/LibP2P/Response/Response.swift
@@ -33,6 +33,11 @@ public struct RawResponse: CustomStringConvertible, Sendable {
     ///
     public var payload: ByteBuffer
 
+    /// When `true`, the responder closes the stream only *after* this response's write
+    /// has completed (i.e. actually reached the socket), rather than racing the close
+    /// against the in-flight write. Used to back `Response.respondThenClose` / `.close`.
+    public var closeAfterWrite: Bool
+
     /// See `CustomStringConvertible`
     public var description: String {
         var desc: [String] = []
@@ -44,9 +49,11 @@ public struct RawResponse: CustomStringConvertible, Sendable {
 
     /// Internal init that creates a new `RawResponse`
     public init(
-        payload: ByteBuffer
+        payload: ByteBuffer,
+        closeAfterWrite: Bool = false
     ) {
         self.payload = payload
+        self.closeAfterWrite = closeAfterWrite
     }
 }
 //public final class RawResponse: CustomStringConvertible, Sendable {
@@ -115,10 +122,15 @@ public enum Response<T: ResponseEncodable & Sendable>: ResponseEncodable, Sendab
         case .respond(let payload):
             return payload.encodeResponse(for: request)
         case .respondThenClose(let payload):
-            return payload.encodeResponse(for: request).always { _ in request.shouldClose() }
+            // Mark the response so the responder closes the stream only after this
+            // write reaches the socket (see `ResponderChannelHandler.serialize`), rather
+            // than closing as soon as the payload is encoded.
+            return payload.encodeResponse(for: request).map { raw in
+                RawResponse(payload: raw.payload, closeAfterWrite: true)
+            }
         case .close, .reset:
-            let res = RawResponse(payload: request.allocator.buffer(bytes: []))
-            return request.eventLoop.makeSucceededFuture(res).always { _ in request.shouldClose() }
+            let res = RawResponse(payload: request.allocator.buffer(bytes: []), closeAfterWrite: true)
+            return request.eventLoop.makeSucceededFuture(res)
         }
     }
 }


### PR DESCRIPTION
### What?
Fix broken write promises

### Changes
- Update Common Channel Handlers to forward promises along the pipeline
- Updated `ResponderChannelHandler` to wait until the write finishes (completes or fails) to issue the close stream request
    - Prevents large writes or writes under heavy load from racing a close call
- Use the new closeAfterWrite api in our `Response` 