### PR TITLE
SecurityUpgradeGate

### DIFF
--- a/Sources/LibP2P/Connections/AppConnection.swift
+++ b/Sources/LibP2P/Connections/AppConnection.swift
@@ -88,6 +88,16 @@ extension AppConnection {
 
                 // - TODO: we might want to be more specific here with the position we're adding our handlers...
                 secUpgrader.upgradeConnection(self, position: .last, securedPromise: promise).flatMap {
+                    // Install a buffering gate at the tail BEFORE removing the security "upgrader".
+                    // Removing "upgrader" can replay buffered bytes before we have our mss-muxer upgrader
+                    // in place to receive them, resulting in dropped bytes. The gate holds them until we
+                    // remove it (in `muxConnection`) once the mss-muxer handler is in place.
+                    self.channel.pipeline.addHandler(
+                        SecurityUpgradeGate(logger: self.logger),
+                        name: "security.gate",
+                        position: .last
+                    )
+                }.flatMap {
                     self.channel.pipeline.removeHandler(name: "upgrader")
                 }.whenComplete { res in
                     switch res {
@@ -151,7 +161,13 @@ extension AppConnection {
             mode: self.mode,
             logger: logger,
             promise: negotiationPromise
-        )
+        ).flatMap {
+            // The muxer negotiation handler is now installed behind the gate. Removing
+            // the gate replays any bytes it buffered during the security→muxer transition.
+            self.channel.pipeline.removeHandler(name: "security.gate").flatMapError { _ in
+                self.channel.eventLoop.makeSucceededVoidFuture()
+            }
+        }
     }
 }
 

--- a/Sources/LibP2P/Connections/ChannelHandlers/SecurityUpgradeGate.swift
+++ b/Sources/LibP2P/Connections/ChannelHandlers/SecurityUpgradeGate.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2026 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+
+/// A passive, connection-owned buffer installed at the pipeline tail during the security→muxer upgrade transition.
+internal final class SecurityUpgradeGate: ChannelInboundHandler, RemovableChannelHandler {
+    public typealias InboundIn = ByteBuffer
+    public typealias InboundOut = ByteBuffer
+
+    /// Bytes received while gating, held until we're removed
+    private var buffer: ByteBuffer?
+
+    private let logger: Logger
+
+    init(logger: Logger) {
+        var logger = logger
+        logger[metadataKey: "SecurityUpgradeGate"] = .string("buffering")
+        self.logger = logger
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        // Buffer everything
+        var incoming = unwrapInboundIn(data)
+        if buffer == nil {
+            buffer = incoming
+        } else {
+            buffer!.writeBuffer(&incoming)
+        }
+    }
+
+    public func channelReadComplete(context: ChannelHandlerContext) {
+        // Absorb read-complete's while gating; we'll fire one when we flush on removal.
+    }
+
+    public func handlerRemoved(context: ChannelHandlerContext) {
+        // Replay anything we buffered while being installed
+        if let buffer, buffer.readableBytes > 0 {
+            self.logger.trace("Forwarding \(buffer.readableBytes) buffered post-security byte(s)")
+            context.fireChannelRead(wrapInboundOut(buffer))
+            context.fireChannelReadComplete()
+        }
+        self.buffer = nil
+    }
+}

--- a/Tests/LibP2PTests/SecurityUpgradeGateTests.swift
+++ b/Tests/LibP2PTests/SecurityUpgradeGateTests.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2026 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import LibP2P
+
+extension LibP2PTests {
+
+    /// Unit tests for `SecurityUpgradeGate` — the passive buffer that closes the security→muxer
+    /// pipeline-reconfiguration window (bytes the peer pipelines behind the security handshake used to be
+    /// dropped before the muxer negotiation handler was installed, causing connection upgrades to fail.
+    @Suite("SecurityUpgradeGateTests")
+    struct SecurityUpgradeGateTests {
+
+        private static func bytes(_ values: [UInt8]) -> ByteBuffer {
+            ByteBuffer(bytes: values)
+        }
+
+        /// Ensure that while the gate is installed it buffers inbound reads and on removal it replays everything it buffered
+        @Test("Buffers inbound while installed, replays on removal")
+        func bufferThenReplayOnRemoval() throws {
+            let channel = EmbeddedChannel()
+            defer { _ = try? channel.finish() }
+
+            let gate = SecurityUpgradeGate(logger: Logger(label: "test.gate"))
+            try channel.pipeline.addHandler(gate).wait()
+
+            // Two separate reads arrive during the gap (e.g. coalesced leftover, then a live read).
+            try channel.writeInbound(Self.bytes([0x01, 0x02, 0x03]))
+            try channel.writeInbound(Self.bytes([0x04, 0x05]))
+
+            // Nothing should have reached the tail while gating.
+            #expect(try channel.readInbound(as: ByteBuffer.self) == nil)
+
+            // Removing the gate (which happens once the muxer negotiation handler is installed) flushes.
+            try channel.pipeline.removeHandler(gate).wait()
+
+            let flushed = try channel.readInbound(as: ByteBuffer.self)
+            #expect(flushed == Self.bytes([0x01, 0x02, 0x03, 0x04, 0x05]))
+            // Exactly one coalesced buffer — no second read.
+            #expect(try channel.readInbound(as: ByteBuffer.self) == nil)
+        }
+
+        /// After the gate is removed it must be fully out of the way — subsequent reads pass straight through.
+        @Test("Passes reads through after removal")
+        func passthroughAfterRemoval() throws {
+            let channel = EmbeddedChannel()
+            defer { _ = try? channel.finish() }
+
+            let gate = SecurityUpgradeGate(logger: Logger(label: "test.gate"))
+            try channel.pipeline.addHandler(gate).wait()
+            try channel.pipeline.removeHandler(gate).wait()
+
+            try channel.writeInbound(Self.bytes([0xAA, 0xBB]))
+            #expect(try channel.readInbound(as: ByteBuffer.self) == Self.bytes([0xAA, 0xBB]))
+        }
+
+        /// Removing an empty gate (no bytes arrived in the window — the common fast path) is a no-op and
+        /// must not crash or emit a spurious empty read.
+        @Test("Empty gate removal forwards nothing")
+        func emptyRemovalIsNoOp() throws {
+            let channel = EmbeddedChannel()
+            defer { _ = try? channel.finish() }
+
+            let gate = SecurityUpgradeGate(logger: Logger(label: "test.gate"))
+            try channel.pipeline.addHandler(gate).wait()
+            try channel.pipeline.removeHandler(gate).wait()
+
+            #expect(try channel.readInbound(as: ByteBuffer.self) == nil)
+        }
+    }
+}


### PR DESCRIPTION
### What?
This PR introduces a `SecurityUpgradeGate` channel handler, whose sole purpose is to buffer inbound bytes during our security -> muxer pipeline reconfiguration. There's a brief moment while we're busy upgrading the pipeline that bytes were sneaking by and ultimately not consumed. This caused connection upgrades to fail and connections to timeout, waiting for data that already passed us by...

The `SecurityUpgradeGate` is installed right after our security module is negotiated, at the end of the pipeline. And it's removed right after the MSS Muxer Negotiator is installed, at which point it replays any data it happened to buffer.