### PR TITLE
ELF vs Async

### DIFF
--- a/Sources/LibP2PTesting/ModuleHarness/MuxerConformanceHarness.swift
+++ b/Sources/LibP2PTesting/ModuleHarness/MuxerConformanceHarness.swift
@@ -303,8 +303,8 @@ public func runMuxerConformance(
             // Fire both closes WITHOUT awaiting completion: a graceful close's future legitimately stays
             // pending until the peer also closes (the hold route never does), so awaiting would spin indefinitely.
             // We only need to prove a second close() doesn't crash or leak a promise. Reaching the check = survived.
-            _ = closeStream.close(gracefully: true)
-            _ = closeStream.close(gracefully: true)
+            _ = closeStream.close(gracefully: true) as EventLoopFuture<Void>
+            _ = closeStream.close(gracefully: true) as EventLoopFuture<Void>
             try? await Task.sleep(nanoseconds: 150 * 1_000_000)
             report.check("close(gracefully:) is idempotent (a second close does not crash)", true)
         } else {

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -161,7 +161,7 @@ extension LibP2PTests {
                 #expect(stream.streamState == .open)
 
                 // Drive the production close path, running the loop so its submitted work resolves.
-                let closeFuture = connection.close()
+                let closeFuture: EventLoopFuture<Void> = connection.close()
                 loop.run()
                 try await closeFuture.get()
 


### PR DESCRIPTION
### What?
- Small fix to explicitly request the EventLoopFuture method over the default async await method (now that https://github.com/swift-libp2p/swift-libp2p-core/pull/11 landed)