### PR TITLE
Identify Protocol Work

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // LibP2P Core
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-core.git", .upToNextMinor(from: "0.5.2")),
         // LibP2P Multiaddr
         .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.2.0")),
         // LibP2P Peer Identities

--- a/Sources/LibP2P/Identify/ID/ChannelHandlers/PartialIdentifyMessageHandler.swift
+++ b/Sources/LibP2P/Identify/ID/ChannelHandlers/PartialIdentifyMessageHandler.swift
@@ -36,6 +36,13 @@ public class PartialIdentifyMessageDecoder: ByteToMessageDecoder {
         // Make sure there's data to be read
         guard buffer.readableBytes > 0 else { return .needMoreData }
 
+        // Backstop against unbounded buffering from a misbehaving / malicious peer.
+        guard buffer.readableBytes <= Identify.maxMessageSize else {
+            context.fireErrorCaught(Errors.invalidIdentifyMessage)
+            buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
+            return .continue
+        }
+
         //Try and decode the Identity Reponse
         guard var remoteIdentify = try? IdentifyMessage(serializedBytes: Data(buffer.readableBytesView)) else {
             return .needMoreData

--- a/Sources/LibP2P/Identify/ID/ChannelHandlers/PartialIdentifyMessageHandler.swift
+++ b/Sources/LibP2P/Identify/ID/ChannelHandlers/PartialIdentifyMessageHandler.swift
@@ -48,63 +48,35 @@ public class PartialIdentifyMessageDecoder: ByteToMessageDecoder {
             return .needMoreData
         }
 
-        if !remoteIdentify.publicKey.isEmpty && !remoteIdentify.signedPeerRecord.isEmpty {
-            // Send the message's bytes up the pipeline to the next handler.
-            context.fireChannelRead(self.wrapInboundOut(buffer))
+        // `publicKey` and `signedPeerRecord` are both optional per the identify spec, so
+        // any message that decodes is forwarded to the route handler immediately. We keep
+        // a best-effort cache of a public key seen without a signed record so that a peer
+        // that splits the two across frames can still have its record verified — but we
+        // never stall waiting for a second frame that may never arrive.
+        let hasPublicKey = !remoteIdentify.publicKey.isEmpty
+        let hasSignedRecord = !remoteIdentify.signedPeerRecord.isEmpty
 
-            // Consume the bytes
-            buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
-
-            // We can keep going if you have more data.
-            return .continue
-
-        } else {
-            // We received a partial identify message...
-            if !remoteIdentify.publicKey.isEmpty && remoteIdentify.signedPeerRecord.isEmpty {
-                // If this message contains the pubkey without the signature then store it in our cache
-                self.partialIdentify = remoteIdentify
-
-                // Consume the bytes
-                buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
-
-                // Wait for the remainder of the IdentifyMessage to come in...
-                return .needMoreData
-
-            } else if !remoteIdentify.signedPeerRecord.isEmpty && remoteIdentify.publicKey.isEmpty,
-                var cachedIdentify = self.partialIdentify
-            {
-                // If this message contains the signature without the pubkey, append the sig to the cached entry and attempt to validate
-                cachedIdentify.signedPeerRecord = remoteIdentify.signedPeerRecord
-
-                // Swap the remote identify message with the cached version and append the signedPeerRecord
-                remoteIdentify = cachedIdentify
-
-                // Consume the bytes
-                buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
-
-                // Send the message's bytes up the pipeline to the next handler.
-                context.fireChannelRead(
-                    self.wrapInboundOut(ByteBuffer(bytes: try remoteIdentify.serializedData().byteArray))
-                )
-
-                // We can keep going if you have more data.
-                return .continue
-
-            } else {
-                //print("PartialIdentifyMessageHandler:SignedPeerRecord is nil: \(remoteIdentify.signedPeerRecord.isEmpty)")
-                //print("PartialIdentifyMessageHandler:PublicKey is nil: \(remoteIdentify.publicKey.isEmpty)")
-                //print(remoteIdentify)
-
-                // Partial identify message received and we're not sure what to do with it...
-                context.fireErrorCaught(Errors.invalidPartialIdentifyMessage)
-
-                // Consume the bytes
-                buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
-
-                // We can keep going if you have more data.
-                return .continue
-            }
+        if hasPublicKey && !hasSignedRecord {
+            // Remember the public key in case a record-only frame follows.
+            self.partialIdentify = remoteIdentify
+        } else if hasSignedRecord && !hasPublicKey, var cachedIdentify = self.partialIdentify {
+            // Reunite a record-only frame with the previously seen public key.
+            cachedIdentify.signedPeerRecord = remoteIdentify.signedPeerRecord
+            remoteIdentify = cachedIdentify
+            self.partialIdentify = nil
+        } else if hasPublicKey && hasSignedRecord {
+            // Complete message — clear any stale cache.
+            self.partialIdentify = nil
         }
+
+        // Consume the bytes and forward the (possibly reassembled) message up the pipeline.
+        buffer.moveReaderIndex(forwardBy: buffer.readableBytes)
+        context.fireChannelRead(
+            self.wrapInboundOut(ByteBuffer(bytes: try remoteIdentify.serializedData().byteArray))
+        )
+
+        // We can keep going if there's more data.
+        return .continue
     }
 
     public func decodeLast(

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -150,26 +150,36 @@ extension Identify {
         do {
             /// Ensure the Payload is an IdentifyMessage
             let remoteIdentify = try IdentifyMessage(serializedBytes: payload)
-            /// and that is valid
-            let signedEnvelope = try SealedEnvelope(
-                marshaledEnvelope: remoteIdentify.signedPeerRecord.byteArray,
-                verifiedWithPublicKey: remoteIdentify.publicKey.byteArray
-            )
-            let peerRecord = try PeerRecord(
-                marshaledData: Data(signedEnvelope.rawPayload),
-                withPublicKey: remoteIdentify.publicKey
-            )
 
-            connection.logger.debug("Identify::\n\(signedEnvelope)")
-            connection.logger.debug("Identify::\n\(peerRecord)")
+            /// The identity of the peer is established by the security handshake, not
+            /// by the contents of the Identify message.
+            guard let identifiedPeer = connection.remotePeer else {
+                connection.logger.warning(
+                    "Identify::Refusing to consume IdentifyMessage on an unauthenticated connection"
+                )
+                return
+            }
+
+            /// The signed peer record is optional per the spec. When present, verify it
+            /// and confirm it belongs to the authenticated peer before trusting it.
+            let peerRecord = self.verifiedPeerRecord(
+                from: remoteIdentify,
+                expectedPeer: identifiedPeer,
+                connection: connection
+            )
 
             connection.logger.trace("Identify::Updating PeerStore with Identified Peer")
-            self.updateIdentifiedPeerInPeerStore(peerRecord, identifyMessage: remoteIdentify, connection: connection)
+            self.updateIdentifiedPeerInPeerStore(
+                identifiedPeer: identifiedPeer,
+                peerRecord: peerRecord,
+                identifyMessage: remoteIdentify,
+                connection: connection
+            )
 
             /// Publish the identifiedPeer event
             self.application?.events.post(
                 .identifiedPeer(
-                    IdentifiedPeer(peer: peerRecord.peerID, identity: try remoteIdentify.serializedData().byteArray)
+                    IdentifiedPeer(peer: identifiedPeer, identity: try remoteIdentify.serializedData().byteArray)
                 )
             )
 
@@ -237,21 +247,30 @@ extension Identify {
         do {
             /// Ensure the Payload is an IdentifyMessage
             let remoteIdentify = try IdentifyMessage(serializedBytes: payload)
-            /// and that is valid
-            let signedEnvelope = try SealedEnvelope(
-                marshaledEnvelope: remoteIdentify.signedPeerRecord.byteArray,
-                verifiedWithPublicKey: remoteIdentify.publicKey.byteArray
-            )
-            let peerRecord = try PeerRecord(
-                marshaledData: Data(signedEnvelope.rawPayload),
-                withPublicKey: remoteIdentify.publicKey
-            )
 
-            connection.logger.debug("Identify::Push::\n\(signedEnvelope)")
-            connection.logger.debug("Identify::Push::\n\(peerRecord)")
+            /// The identity of the peer is established by the security handshake, not
+            /// by the contents of the Identify message.
+            guard let identifiedPeer = connection.remotePeer else {
+                connection.logger.warning("Identify::Push::Refusing to consume push on an unauthenticated connection")
+                return
+            }
+
+            /// Optional signed record, verified and bound to the authenticated peer.
+            let peerRecord = self.verifiedPeerRecord(
+                from: remoteIdentify,
+                expectedPeer: identifiedPeer,
+                connection: connection
+            )
 
             connection.logger.trace("Identify::Push::Updating PeerStore with Identified Peer")
-            self.updateIdentifiedPeerInPeerStore(peerRecord, identifyMessage: remoteIdentify, connection: connection)
+            /// Push messages are partial updates: only the fields present should be applied
+            self.updateIdentifiedPeerInPeerStore(
+                identifiedPeer: identifiedPeer,
+                peerRecord: peerRecord,
+                identifyMessage: remoteIdentify,
+                connection: connection,
+                isPartialUpdate: true
+            )
 
             connection.logger.trace(
                 "Identify::Push::Successfully Updated Identified Remote Peer using the Identify Push Protocol"

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -25,6 +25,9 @@ public final class Identify: IdentityManager, CustomStringConvertible {
     /// Maximum size (in bytes) we're willing to buffer/accept for a single Identify message.
     static let maxMessageSize: Int = 8 * 1024
 
+    /// Outbound Ping Timeout
+    static let pingTimeout: TimeAmount = .seconds(3)
+    
     let application: Application?
     let localPeerID: PeerID
     private let logger: Logger
@@ -371,8 +374,8 @@ extension Identify {
             self.pingCache.withLockedValue { pings in
                 if let outstandingPing = pings[peer.id] {
                     // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
-                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
-                        print("We have an outstanding ping thats older than 3 seconds")
+                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > Identify.pingTimeout.nanoseconds {
+                        self.logger.trace("Identify::Ping::Outstanding ping older than our timeout, failing it")
                         outstandingPing.promise?.fail(Errors.timedOut)
                     } else if let promise = outstandingPing.promise {
                         // If the outstanding ping hasn't timed out yet, just return the results of the existing promise
@@ -407,8 +410,8 @@ extension Identify {
                 }
                 if let outstandingPing = pings[peer.id] {
                     // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
-                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > 3_000_000_000 {
-                        print("We have an outstanding ping thats older than 3 seconds")
+                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > Identify.pingTimeout.nanoseconds {
+                        self.logger.trace("Identify::Ping::Outstanding ping older than our timeout, failing it")
                         outstandingPing.promise?.fail(Errors.timedOut)
                     } else if let promise = outstandingPing.promise {
                         // If the outstanding ping hasn't timed out yet, just return the results of the existing promise

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -27,7 +27,7 @@ public final class Identify: IdentityManager, CustomStringConvertible {
 
     /// Outbound Ping Timeout
     static let pingTimeout: TimeAmount = .seconds(3)
-    
+
     let application: Application?
     let localPeerID: PeerID
     private let logger: Logger
@@ -487,7 +487,9 @@ extension Identify {
             self.pingCache.withLockedValue { pings in
                 if let outstandingPing = pings[peer.id] {
                     // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
-                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > Identify.pingTimeout.nanoseconds {
+                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime
+                        > Identify.pingTimeout.nanoseconds
+                    {
                         self.logger.trace("Identify::Ping::Outstanding ping older than our timeout, failing it")
                         outstandingPing.promise?.fail(Errors.timedOut)
                     } else if let promise = outstandingPing.promise {
@@ -523,7 +525,9 @@ extension Identify {
                 }
                 if let outstandingPing = pings[peer.id] {
                     // If the outstanding ping has been in flight for more than 3 seconds, fail the promise
-                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime > Identify.pingTimeout.nanoseconds {
+                    if DispatchTime.now().uptimeNanoseconds - outstandingPing.startTime
+                        > Identify.pingTimeout.nanoseconds
+                    {
                         self.logger.trace("Identify::Ping::Outstanding ping older than our timeout, failing it")
                         outstandingPing.promise?.fail(Errors.timedOut)
                     } else if let promise = outstandingPing.promise {

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -84,6 +84,9 @@ public final class Identify: IdentityManager, CustomStringConvertible {
         /// Register our event listeners
         application.events.on(self, event: .upgraded(self.onNewConnection))
         application.events.on(self, event: .disconnected(self.onDisconnected))
+        /// When our own listen addresses change, proactively push the update to peers.
+        application.events.on(self, event: .listen(self.onLocalListenAddressesChanged))
+        application.events.on(self, event: .listenClosed(self.onLocalListenAddressesChanged))
 
         self.logger.trace("Initialized!")
     }
@@ -127,6 +130,13 @@ public final class Identify: IdentityManager, CustomStringConvertible {
         connection.logger.trace(
             "Identify::Connection to peer was closed, clean up / finalize any outstanding Identify data"
         )
+    }
+
+    /// Fired when one of our local listen addresses is added or removed. Per the identify
+    /// spec's push variant, we proactively inform connected peers of the change.
+    internal func onLocalListenAddressesChanged(_ proto: String, _ addr: Multiaddr) {
+        self.logger.trace("Identify::Local listen addresses changed (\(addr)); pushing update to peers")
+        self.push()
     }
 }
 
@@ -363,6 +373,32 @@ extension Identify {
                     RemotePeerProtocolChange(peer: identifiedPeer, protocols: protocols, connection: connection)
                 )
             )
+        }
+    }
+}
+
+/// Push Methods
+extension Identify {
+    /// Proactively pushes our current Identify state to every connected, authenticated
+    /// peer using the `/ipfs/id/push/1.0.0` protocol.
+    ///
+    /// Call this after our listen addresses or supported protocols change. Opening the
+    /// stream triggers the registered push route responder, which sends the message on
+    /// the outbound stream's `.ready` event (see `handlePushRequest`).
+    public func push() {
+        guard let application = application else { return }
+        application.connections.getConnections(on: nil).whenComplete { result in
+            switch result {
+            case .failure(let error):
+                self.logger.warning("Identify::Push::Failed to enumerate connections: \(error)")
+            case .success(let connections):
+                let targets = connections.filter { $0.remotePeer != nil && $0.status != .closed }
+                guard !targets.isEmpty else { return }
+                self.logger.trace("Identify::Push::Pushing updated Identify to \(targets.count) peer(s)")
+                for connection in targets {
+                    connection.newStream(forProtocol: Identify.Multicodecs.PUSH)
+                }
+            }
         }
     }
 }

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -22,6 +22,9 @@ import NIOConcurrencyHelpers
 public final class Identify: IdentityManager, CustomStringConvertible {
     static let protocolVersion: String = "ipfs/0.1.0"
 
+    /// Maximum size (in bytes) we're willing to buffer/accept for a single Identify message.
+    static let maxMessageSize: Int = 8 * 1024
+
     let application: Application?
     let localPeerID: PeerID
     private let logger: Logger

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -182,6 +182,50 @@ extension Identify {
             return
         }
     }
+
+    /// Verifies the optional signed peer record carried in an Identify message.
+    ///
+    /// Returns the verified `PeerRecord` only when:
+    /// - both `publicKey` and `signedPeerRecord` are present,
+    /// - the envelope signature validates against the advertised public key, and
+    /// - the record's peer ID matches the peer we authenticated on this connection.
+    ///
+    /// Otherwise returns `nil` (the caller still stores the message's unsigned fields).
+    private func verifiedPeerRecord(
+        from remoteIdentify: IdentifyMessage,
+        expectedPeer: PeerID,
+        connection: Connection
+    ) -> PeerRecord? {
+        guard !remoteIdentify.signedPeerRecord.isEmpty, !remoteIdentify.publicKey.isEmpty else {
+            connection.logger.trace("Identify::No signed peer record present, storing unsigned fields only")
+            return nil
+        }
+        do {
+            let signedEnvelope = try SealedEnvelope(
+                marshaledEnvelope: remoteIdentify.signedPeerRecord.byteArray,
+                verifiedWithPublicKey: remoteIdentify.publicKey.byteArray
+            )
+            let peerRecord = try PeerRecord(
+                marshaledData: Data(signedEnvelope.rawPayload),
+                withPublicKey: remoteIdentify.publicKey
+            )
+            /// The record must belong to the same peer that opened this stream
+            guard peerRecord.peerID == expectedPeer else {
+                connection.logger.warning(
+                    "Identify::Signed peer record identity (\(peerRecord.peerID.b58String)) does not match the authenticated peer (\(expectedPeer.b58String)); ignoring record"
+                )
+                return nil
+            }
+            connection.logger.debug("Identify::\n\(signedEnvelope)")
+            connection.logger.debug("Identify::\n\(peerRecord)")
+            return peerRecord
+        } catch {
+            connection.logger.warning(
+                "Identify::Failed to verify signed peer record -> \(error); storing unsigned fields only"
+            )
+            return nil
+        }
+    }
 }
 
 extension Identify {

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -36,6 +36,7 @@ public final class Identify: IdentityManager, CustomStringConvertible {
 
     public enum Errors: Error {
         case timedOut
+        case unknownIdentityManager
     }
 
     internal struct PendingPing {

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -309,15 +309,16 @@ extension Identify {
 /// PeerStore Update Methods
 extension Identify {
     private func updateIdentifiedPeerInPeerStore(
-        _ peerRecord: PeerRecord,
+        identifiedPeer: PeerID,
+        peerRecord: PeerRecord?,
         identifyMessage: IdentifyMessage,
-        connection: Connection
+        connection: Connection,
+        isPartialUpdate: Bool = false
     ) {
         guard let application = application else {
             connection.logger.error("Identify::Lost reference to our Application")
             return
         }
-        let identifiedPeer = peerRecord.peerID
         guard identifiedPeer != application.peerID else { return }
         connection.logger.trace("Identify::Identified Remote Peer")
 
@@ -326,35 +327,42 @@ extension Identify {
         // This call to add key will only update/upgrade the PeerID in the PeerStore, it wont 'downgrade' an existing PeerID
         tasks.append(application.peers.add(key: identifiedPeer, on: connection.channel.eventLoop))
 
-        // Update our peers listening addresses
-        let listeningAddresses = identifyMessage.listenAddrs.compactMap { multiaddrData -> Multiaddr? in
-            if let ma = try? Multiaddr(multiaddrData) {
-                if !ma.protocols().contains(.p2p) {
-                    return try? ma.encapsulate(proto: .p2p, address: identifiedPeer.b58String)
-                } else {
-                    return ma
+        // Update our peers listening addresses.
+        // For partial (push) updates an empty list means "no change", so we skip it
+        if !identifyMessage.listenAddrs.isEmpty {
+            let listeningAddresses = identifyMessage.listenAddrs.compactMap { multiaddrData -> Multiaddr? in
+                if let ma = try? Multiaddr(multiaddrData) {
+                    if !ma.protocols().contains(.p2p) {
+                        return try? ma.encapsulate(proto: .p2p, address: identifiedPeer.b58String)
+                    } else {
+                        return ma
+                    }
                 }
+                return nil
             }
-            return nil
-        }
-        tasks.append(
-            application.peers.add(
-                addresses: listeningAddresses,
-                toPeer: identifiedPeer,
-                on: connection.channel.eventLoop
+            tasks.append(
+                application.peers.add(
+                    addresses: listeningAddresses,
+                    toPeer: identifiedPeer,
+                    on: connection.channel.eventLoop
+                )
             )
-        )
+        }
 
-        // Update our peers known protocols
+        // Update our peers known protocols (skip empty lists on partial updates).
         let protocols = identifyMessage.protocols.compactMap { SemVerProtocol($0) }
-        connection.logger.trace("Identify::Adding known protocols to peer \(identifiedPeer.b58String)")
-        connection.logger.trace("Identify::\(protocols.map({ $0.stringValue }).joined(separator: ","))")
-        tasks.append(
-            application.peers.add(protocols: protocols, toPeer: identifiedPeer, on: connection.channel.eventLoop)
-        )
+        if !protocols.isEmpty {
+            connection.logger.trace("Identify::Adding known protocols to peer \(identifiedPeer.b58String)")
+            connection.logger.trace("Identify::\(protocols.map({ $0.stringValue }).joined(separator: ","))")
+            tasks.append(
+                application.peers.add(protocols: protocols, toPeer: identifiedPeer, on: connection.channel.eventLoop)
+            )
+        }
 
-        // Add the PeerRecord to our Records list
-        tasks.append(application.peers.add(record: peerRecord, on: connection.channel.eventLoop))
+        // Add the (verified) PeerRecord to our Records list when one is present.
+        if let peerRecord = peerRecord {
+            tasks.append(application.peers.add(record: peerRecord, on: connection.channel.eventLoop))
+        }
 
         // Update our peers metadata (agent version, protocol version, etc.. maybe include a verified attribute (the signed peer record))
         connection.logger.trace("Identify::Adding Metadata to peer \(identifiedPeer.b58String)")
@@ -397,7 +405,7 @@ extension Identify {
             )
         }
 
-        // -TODO: Our Connection should do this when we complete our security handshake, also we should remove this here...
+        // TODO: Our Connection should do this when we complete our security handshake, also we should remove this here...
         tasks.append(
             application.peers.add(
                 metaKey: .LastHandshake,
@@ -412,6 +420,9 @@ extension Identify {
             connection.logger.trace(
                 "Identify::Done Adding Metadata to PeerStore. Alerting Application to Remote Peer Protocol Change."
             )
+            // On a partial (push) update with no protocol change there's nothing to
+            // report, so avoid emitting a misleading empty protocol-change event.
+            guard !isPartialUpdate || !protocols.isEmpty else { return }
             application.events.post(
                 .remotePeerProtocolChange(
                     RemotePeerProtocolChange(peer: identifiedPeer, protocols: protocols, connection: connection)

--- a/Sources/LibP2P/Identify/ID/ID.swift
+++ b/Sources/LibP2P/Identify/ID/ID.swift
@@ -301,8 +301,10 @@ extension Identify {
 
         var id = IdentifyMessage()
         id.publicKey = try self.localPeerID.keyPair!.publicKey.marshal()
-        //let registeredProtos = self.libp2p?.registeredProtocols.compactMap { $0.protocolString() } ?? []
+        // TODO: We need a way to filter out protocols we don't want to advertise
+        // (like local only protocols, outbound only protocols, or protocols for certain peers only, deprecated protocols (like Delta)
         let registeredProtos = req.application.routes.all.compactMap { $0.description }
+            .filter { $0 != Identify.Multicodecs.DELTA }
         id.protocols = registeredProtos
         id.protocolVersion = Identify.protocolVersion
         id.agentVersion = req.application.agentVersion

--- a/Sources/LibP2P/Identify/ID/ID_Routes.swift
+++ b/Sources/LibP2P/Identify/ID/ID_Routes.swift
@@ -73,6 +73,10 @@ func routes(_ app: Application) throws {
         p2p.group("id", handlers: [.varIntLengthPrefixed]) { id in
 
             // Route Group: p2p/id/delta/...
+            // NOTE: The delta message has been removed from current go-libp2p, so delta
+            // is legacy. We still register the handler to accept inbound deltas, but we
+            // filter it out of our advertised protocol list in `constructIdentifyMessage`.
+            // The modern replacement is identify/push.
             id.group("delta") { delta in
 
                 // Route Endpoint: p2p/id/delta/1.0.0

--- a/Sources/LibP2P/Identify/ID/Protobuf/Identify.pb.swift
+++ b/Sources/LibP2P/Identify/ID/Protobuf/Identify.pb.swift
@@ -21,15 +21,11 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/apple/swift-protobuf/
 
-//
-//  IdentifyProto.proto
-//
-//  Created by Libp2p
-//  Modified by Brandon Toms on 5/1/22.
-//
-// https://github.com/libp2p/specs/blob/master/identify/README.md
-
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file
@@ -65,22 +61,22 @@ struct IdentifyMessage: Sendable {
 
   /// protocolVersion determines compatibility between peers
   var protocolVersion: String {
-    get {return _protocolVersion ?? String()}
+    get {_protocolVersion ?? String()}
     set {_protocolVersion = newValue}
   }
   /// Returns true if `protocolVersion` has been explicitly set.
-  var hasProtocolVersion: Bool {return self._protocolVersion != nil}
+  var hasProtocolVersion: Bool {self._protocolVersion != nil}
   /// Clears the value of `protocolVersion`. Subsequent reads from it will return its default value.
   mutating func clearProtocolVersion() {self._protocolVersion = nil}
 
   /// agentVersion is like a UserAgent string in browsers, or client version in
   /// bittorrent includes the client name and client.
   var agentVersion: String {
-    get {return _agentVersion ?? String()}
+    get {_agentVersion ?? String()}
     set {_agentVersion = newValue}
   }
   /// Returns true if `agentVersion` has been explicitly set.
-  var hasAgentVersion: Bool {return self._agentVersion != nil}
+  var hasAgentVersion: Bool {self._agentVersion != nil}
   /// Clears the value of `agentVersion`. Subsequent reads from it will return its default value.
   mutating func clearAgentVersion() {self._agentVersion = nil}
 
@@ -88,11 +84,11 @@ struct IdentifyMessage: Sendable {
   /// - may not need to be sent, as secure channel implies it has been sent.
   /// - then again, if we change / disable secure channel, may still want it.
   var publicKey: Data {
-    get {return _publicKey ?? Data()}
+    get {_publicKey ?? Data()}
     set {_publicKey = newValue}
   }
   /// Returns true if `publicKey` has been explicitly set.
-  var hasPublicKey: Bool {return self._publicKey != nil}
+  var hasPublicKey: Bool {self._publicKey != nil}
   /// Clears the value of `publicKey`. Subsequent reads from it will return its default value.
   mutating func clearPublicKey() {self._publicKey = nil}
 
@@ -105,11 +101,11 @@ struct IdentifyMessage: Sendable {
   /// helps the remote endpoint determine whether its connection to the local
   /// peer goes through NAT.
   var observedAddr: Data {
-    get {return _observedAddr ?? Data()}
+    get {_observedAddr ?? Data()}
     set {_observedAddr = newValue}
   }
   /// Returns true if `observedAddr` has been explicitly set.
-  var hasObservedAddr: Bool {return self._observedAddr != nil}
+  var hasObservedAddr: Bool {self._observedAddr != nil}
   /// Clears the value of `observedAddr`. Subsequent reads from it will return its default value.
   mutating func clearObservedAddr() {self._observedAddr = nil}
 
@@ -119,11 +115,11 @@ struct IdentifyMessage: Sendable {
   /// a delta update is incompatible with everything else. If this field is
   /// included, none of the others can appear.
   var delta: Delta {
-    get {return _delta ?? Delta()}
+    get {_delta ?? Delta()}
     set {_delta = newValue}
   }
   /// Returns true if `delta` has been explicitly set.
-  var hasDelta: Bool {return self._delta != nil}
+  var hasDelta: Bool {self._delta != nil}
   /// Clears the value of `delta`. Subsequent reads from it will return its default value.
   mutating func clearDelta() {self._delta = nil}
 
@@ -135,11 +131,11 @@ struct IdentifyMessage: Sendable {
   /// github.com/libp2p/go-libp2p-core/peer/pb/peer_record.proto for message
   /// definitions.
   var signedPeerRecord: Data {
-    get {return _signedPeerRecord ?? Data()}
+    get {_signedPeerRecord ?? Data()}
     set {_signedPeerRecord = newValue}
   }
   /// Returns true if `signedPeerRecord` has been explicitly set.
-  var hasSignedPeerRecord: Bool {return self._signedPeerRecord != nil}
+  var hasSignedPeerRecord: Bool {self._signedPeerRecord != nil}
   /// Clears the value of `signedPeerRecord`. Subsequent reads from it will return its default value.
   mutating func clearSignedPeerRecord() {self._signedPeerRecord = nil}
 

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID.swift
@@ -26,10 +26,12 @@ internal func handleIDRequest(_ req: Request) -> Response<ByteBuffer> {
         req.logger.trace("Identify::/ipfs/id/1.0.0 => New Stream Ready...")
 
         // Construct and send our outbound Identify message
-        if let res = handleOutboundIdentifyMessage(req) {
+        do {
+            let res = try handleOutboundIdentifyMessage(req)
             return .respondThenClose(res)
-        } else {
-            return .close  // TODO: Should be reset...
+        } catch {
+            req.logger.error("Identify::Failed to construct outbound Identify message: \(error)")
+            return .reset(error)
         }
 
     case .data(let payload):
@@ -67,19 +69,13 @@ private func handleInboundIdentifyMessage(_ req: Request, payload: ByteBuffer) {
     return
 }
 
-private func handleOutboundIdentifyMessage(_ req: Request) -> ByteBuffer? {
-    //Send the identify message
-    do {
-        /// TODO: Fix this! We need to cast to Identify in order to construct our message becuase Request isn't part of LibP2PCore
-        guard let manager = req.application.identify as? Identify else {
-            req.logger.error("Identify::Unknown IdentityManager. Unable to contruct identify message")
-            return nil
-        }
-        let idMessage = try manager.constructIdentifyMessage(req: req)
-        req.logger.info("Identify::Sending Identify Payload to \(String(describing: req.remotePeer))")
-        return req.allocator.buffer(bytes: idMessage)
-    } catch {
-        req.logger.error("Identify::Error while constructing Identify Message: \(error)")
-        return nil
+private func handleOutboundIdentifyMessage(_ req: Request) throws -> ByteBuffer {
+    /// TODO: Fix this! We need to cast to Identify in order to construct our message becuase Request isn't part of LibP2PCore
+    guard let manager = req.application.identify as? Identify else {
+        req.logger.error("Identify::Unknown IdentityManager. Unable to contruct identify message")
+        throw Identify.Errors.unknownIdentityManager
     }
+    let idMessage = try manager.constructIdentifyMessage(req: req)
+    req.logger.info("Identify::Sending Identify Payload to \(String(describing: req.remotePeer))")
+    return req.allocator.buffer(bytes: idMessage)
 }

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
@@ -51,7 +51,8 @@ private func handleDeltaMessage(_ req: Request) {
 
     let delta = message.delta
 
-    guard !delta.addedProtocols.isEmpty && !delta.rmProtocols.isEmpty else {
+    // A delta may carry additions only, removals only, or both
+    guard !delta.addedProtocols.isEmpty || !delta.rmProtocols.isEmpty else {
         req.logger.error("Identify::Delta::Empty Delta message, nothing to do...")
         return
     }

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
@@ -59,11 +59,11 @@ private func handleDeltaMessage(_ req: Request) {
 
     var tasks: [EventLoopFuture<Void>] = []
 
-    // Remove old protocols
+    // Remove dropped protocols
     if !delta.rmProtocols.isEmpty {
         tasks.append(
             req.application.peers.remove(
-                protocols: delta.addedProtocols.compactMap {
+                protocols: delta.rmProtocols.compactMap {
                     SemVerProtocol($0)
                 },
                 fromPeer: remotePeer,

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Delta.swift
@@ -43,6 +43,12 @@ private func handleDeltaMessage(_ req: Request) {
         return
     }
 
+    // Ensure we have a remote peer available
+    guard let remotePeer = req.remotePeer else {
+        req.logger.error("Identify::Delta::Cannot apply delta on an unauthenticated stream")
+        return
+    }
+
     let delta = message.delta
 
     guard !delta.addedProtocols.isEmpty && !delta.rmProtocols.isEmpty else {
@@ -59,7 +65,7 @@ private func handleDeltaMessage(_ req: Request) {
                 protocols: delta.addedProtocols.compactMap {
                     SemVerProtocol($0)
                 },
-                fromPeer: req.remotePeer!,
+                fromPeer: remotePeer,
                 on: req.eventLoop
             )
         )
@@ -72,7 +78,7 @@ private func handleDeltaMessage(_ req: Request) {
                 protocols: delta.addedProtocols.compactMap {
                     SemVerProtocol($0)
                 },
-                toPeer: req.remotePeer!,
+                toPeer: remotePeer,
                 on: req.eventLoop
             )
         )
@@ -80,7 +86,7 @@ private func handleDeltaMessage(_ req: Request) {
 
     // Get new set of supported protocols
     tasks.flatten(on: req.eventLoop).flatMap { Void -> EventLoopFuture<[SemVerProtocol]> in
-        req.application.peers.getProtocols(forPeer: req.remotePeer!, on: req.eventLoop)
+        req.application.peers.getProtocols(forPeer: remotePeer, on: req.eventLoop)
     }.whenComplete { result in
         switch result {
         case .failure(let error):
@@ -91,7 +97,7 @@ private func handleDeltaMessage(_ req: Request) {
             req.application.events.post(
                 .remotePeerProtocolChange(
                     RemotePeerProtocolChange(
-                        peer: req.remotePeer!,
+                        peer: remotePeer,
                         protocols: protocols,
                         connection: req.connection
                     )

--- a/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
+++ b/Sources/LibP2P/Identify/ID/RouteHandlers/IPFS_ID_Push.swift
@@ -13,33 +13,50 @@
 //===----------------------------------------------------------------------===//
 
 internal func handlePushRequest(_ req: Request) -> Response<ByteBuffer> {
-    guard req.streamDirection == .inbound else {
-        req.logger.error("Identify::Push::Error - We dont support outbound /ipfs/id/push messages on this handler")
-        return .close
-    }
-
-    switch req.event {
-    case .ready:
-        return .stayOpen
-
-    case .data(let payload):
-        guard let manager = req.application.identify as? Identify else {
-            req.logger.error("Identify::Unknown IdentityManager. Unable to contruct identify message")
-            return .close
+    switch req.streamDirection {
+    case .outbound:
+        // We opened this stream to proactively push our current Identify state to the
+        // remote peer. Send it on `.ready` and close, mirroring the inbound id responder.
+        guard case .ready = req.event else { return .close }
+        do {
+            guard let manager = req.application.identify as? Identify else {
+                req.logger.error("Identify::Push::Unknown IdentityManager. Unable to construct push message")
+                throw Identify.Errors.unknownIdentityManager
+            }
+            let idMessage = try manager.constructIdentifyMessage(req: req)
+            req.logger.trace("Identify::Push::Sending push to \(String(describing: req.remotePeer))")
+            return .respondThenClose(req.allocator.buffer(bytes: idMessage))
+        } catch {
+            req.logger.error("Identify::Push::Failed to construct push message: \(error)")
+            return .reset(error)
         }
 
-        /// Update values that are present...
-        req.logger.warning("Identify::Push::We haven't tested this yet!")
-        manager.consumePushIdentifyMessage(
-            payload: Data(payload.readableBytesView),
-            id: req.remotePeer!.b58String,
-            connection: req.connection
-        )
-        return .close
+    case .inbound:
+        switch req.event {
+        case .ready:
+            return .stayOpen
 
-    default:
-        break
+        case .data(let payload):
+            guard let manager = req.application.identify as? Identify else {
+                req.logger.error("Identify::Unknown IdentityManager. Unable to contruct identify message")
+                return .close
+            }
+
+            guard let remotePeer = req.remotePeer else {
+                req.logger.error("Identify::Push::Refusing to process push on an unauthenticated stream")
+                return .close
+            }
+
+            /// Update values that are present...
+            manager.consumePushIdentifyMessage(
+                payload: Data(payload.readableBytesView),
+                id: remotePeer.b58String,
+                connection: req.connection
+            )
+            return .close
+
+        default:
+            return .close
+        }
     }
-
-    return .close
 }


### PR DESCRIPTION
### What?
The PR revisits the embedded Identify protocol (`/ipfs/id`, `/ipfs/id/push` and `/ipfs/id/ping`)

### Changes:
- Decoder
    - Max buffer check to ensure we don't buffer unbounded data from a bad peer 
    - We no longer assume we'll receive a follow up Signed Peer Record after receiving a lone Public Key
        - Previously we would wait for the Signed Peer Record that may never come and hit our stream timeout
- Delta Protocol
    - Deprecate Delta protocol (we no longer use it but we'll still respond to inbound delta messages)
- Support Outbound Pushes on changes of our listen addresses 
- Reworked our Identify message parsing
    - We used to require a complete Identify message, pub key and signed peer record, but the spec says those are both optional. 
    - So now we use the authenticated peer for the stream the data showed up on as the ground truth for who the Identify message is identifying. And we update partial unsigned fields for that user when the signed peer record isn't included. 
- Regenerated the `IdentifyMessage` protobuf  

> [!NOTE]
> The breaking change is a new error case, since we're not at a major version release yet, I haven't been treating error enum cases as actual breaking changes. Sorry if it causes anyone issues. 