### PR TITLE
Enable DNS Hosts

### DIFF
--- a/Sources/LibP2P/Clients/Client+Utils.swift
+++ b/Sources/LibP2P/Clients/Client+Utils.swift
@@ -247,9 +247,9 @@ extension Application {
     private func resolveAddressIfNecessary(_ ma: Multiaddr, on loop: EventLoop) -> EventLoopFuture<[Multiaddr]?> {
         guard let f = ma.addresses.first else { return loop.makeSucceededFuture(nil) }
         switch f.codec {
-        case .ip4, .ip6, .udp:
+        case .ip4, .ip6, .udp, .dns, .dns4, .dns6:
             return loop.makeSucceededFuture([ma])
-        case .dns, .dnsaddr:
+        case .dnsaddr:
             return self.resolve(ma)
         default:
             self.logger.error("We don't support `\(f.codec) yet!`")
@@ -264,9 +264,9 @@ extension Application {
     ) -> EventLoopFuture<Multiaddr?> {
         guard let f = ma.addresses.first else { return loop.makeSucceededFuture(nil) }
         switch f.codec {
-        case .ip4, .ip6, .udp:
+        case .ip4, .ip6, .udp, .dns, .dns4, .dns6:
             return loop.makeSucceededFuture(ma)
-        case .dns, .dnsaddr:
+        case .dnsaddr:
             return self.resolve(ma, for: codecs)
         default:
             self.logger.error("We don't support `\(f.codec) yet!`")

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -23,8 +23,6 @@ public protocol AddressResolver: Sendable {
     static var key: String { get }
     func resolve(multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?>
     func resolve(multiaddr: Multiaddr, for: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?>
-    //func resolve(multiaddr:Multiaddr) -> EventLoopFuture<[Multiaddr]?>
-    //func resolve(multiaddr:Multiaddr, for:Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?>
 }
 
 extension Application {
@@ -44,27 +42,9 @@ extension Application {
         return true
     }
 
-    //    public func resolve(_ multiaddr:Multiaddr, for codecs:Set<MultiaddrProtocol>) -> Multiaddr? {
-    //        self.logger.trace("Attempting to resolve \(multiaddr) for codecs: \(codecs)")
-    //        guard multiaddr.addresses.first?.codec == .dnsaddr else {
-    //            self.logger.info("Unable to resolve \(multiaddr) for codecs: \(codecs)")
-    //            return nil
-    //        }
-    //
-    //        var resolvedAddress:Multiaddr? = nil
-    //        for resolver in self.resolvers.allResolvers {
-    //            if let addy = resolver.resolve(multiaddr: multiaddr, for: codecs) {
-    //                resolvedAddress = addy
-    //                break
-    //            }
-    //        }
-    //
-    //        if resolvedAddress == nil {
-    //            self.logger.info("Unable to resolve \(multiaddr) for codecs: \(codecs)")
-    //        }
-    //
-    //        return resolvedAddress
-    //    }
+    public func resolve(_ multiaddr: Multiaddr) async throws -> [Multiaddr]? {
+        try await self.resolve(multiaddr).get()
+    }
 
     public func resolve(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
         self.logger.trace("Attempting to resolve \(multiaddr)")
@@ -94,6 +74,10 @@ extension Application {
                 return el.makeSucceededFuture(Array(uniqueSet))
             }
         }
+    }
+
+    public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) async throws -> Multiaddr? {
+        try await self.resolve(multiaddr, for: codecs).get()
     }
 
     public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?> {

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -49,7 +49,7 @@ extension Application {
     public func resolve(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
         self.logger.trace("Attempting to resolve \(multiaddr)")
         let el = self.eventLoopGroup.next()
-        guard multiaddr.addresses.first?.codec == .dnsaddr else {
+        guard isMultiaddrResolvable(multiaddr) else {
             self.logger.info("Unable to resolve \(multiaddr)")
             return el.makeSucceededFuture(nil)
         }
@@ -81,10 +81,10 @@ extension Application {
     }
 
     public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?> {
-        self.logger.trace("Attempting to resolve \(multiaddr)")
+        self.logger.trace("Attempting to resolve \(multiaddr) for \(self.list(codecs))")
         let el = self.eventLoopGroup.next()
-        guard multiaddr.addresses.first?.codec == .dnsaddr else {
-            self.logger.info("Unable to resolve \(multiaddr)")
+        guard isMultiaddrResolvable(multiaddr) else {
+            self.logger.info("Unable to resolve \(multiaddr) for \(self.list(codecs))")
             return el.makeSucceededFuture(nil)
         }
 
@@ -101,7 +101,7 @@ extension Application {
                 let uniqueSet = Set(allAddress.compactMap { $0 })
 
                 guard !uniqueSet.isEmpty else {
-                    self.logger.info("Unable to resolve \(multiaddr)")
+                    self.logger.info("Unable to resolve \(multiaddr) for \(self.list(codecs))")
                     return el.makeSucceededFuture(nil)
                 }
 
@@ -110,13 +110,23 @@ extension Application {
         }
     }
 
+    /// Pretty prints a MultiaddrProtocol set
+    private func list(_ codecs: Set<MultiaddrProtocol>) -> String {
+        "[\(codecs.map({ $0.name }).joined(separator: ","))]"
+    }
+
+    /// Checks our PeerStore for a cached address to dial for the given Multiaddr
+    ///
+    /// - Note: There is no active TTL mechanism here
     private func isCached(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]> {
         let el = self.eventLoopGroup.next()
 
-        /// Search by PeerID if possible...
+        // Search by PeerID if possible
+        // Note: We end up saving the resolved address in our peerstore, so usually a peerID lookup is the only way to find a hit
         if let pid = try? multiaddr.getPeerID() {
             return self.peers.getAddresses(forPeer: pid, on: el).flatMapAlways {
                 result -> EventLoopFuture<[Multiaddr]> in
+                // TODO: Should we check the last handshake time as a TTL
                 switch result {
                 case .success(let addresses):
                     return el.makeSucceededFuture(
@@ -129,6 +139,7 @@ extension Application {
         } else {  // Search by multiaddr
             return self.peers.getPeerInfo(byAddress: multiaddr, on: el).flatMapAlways {
                 result -> EventLoopFuture<[Multiaddr]> in
+                // TODO: Should we check the last handshake time as a TTL
                 switch result {
                 case .success(let peerInfo):
                     return el.makeSucceededFuture(

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -28,37 +28,21 @@ public protocol AddressResolver: Sendable {
 }
 
 extension Application {
+
+    /// A list of codecs that our installed resolvers *might* be able to resolve
+    static let DNSCodecs: Set<MultiaddrProtocol> = [.dns, .dns4, .dns6, .dnsaddr]
+
     public var resolvers: Resolvers {
         .init(application: self)
     }
 
-    //    public func resolve(_ multiaddr:Multiaddr) -> [Multiaddr]? {
-    //        self.logger.trace("Attempting to resolve \(multiaddr)")
-    //        guard multiaddr.addresses.first?.codec == .dnsaddr else {
-    //            self.logger.info("Unable to resolve \(multiaddr)")
-    //            return nil
-    //        }
-    //
-    //        var resolvedAddress:[Multiaddr]? = nil
-    //
-    //        /// Should we check our peerstore for the address in question? and return cached results, if any?
-    //
-    //        for resolver in self.resolvers.allResolvers {
-    //            if let addy = resolver.resolve(multiaddr: multiaddr), !addy.isEmpty {
-    //                resolvedAddress = addy
-    //                break
-    //            }
-    //        }
-    //
-    //        if resolvedAddress == nil {
-    //            self.logger.info("Unable to resolve \(multiaddr)")
-    //        }
-    //
-    //        /// Should we attempt to cache the resolved address in the peer store?
-    //
-    //
-    //        return resolvedAddress
-    //    }
+    /// Compares the leading codec of the given `Multiaddr` against our set of `DNSCodecs`
+    private func isMultiaddrResolvable(_ ma: Multiaddr) -> Bool {
+        guard let codec = ma.addresses.first?.codec, Application.DNSCodecs.contains(codec) else {
+            return false
+        }
+        return true
+    }
 
     //    public func resolve(_ multiaddr:Multiaddr, for codecs:Set<MultiaddrProtocol>) -> Multiaddr? {
     //        self.logger.trace("Attempting to resolve \(multiaddr) for codecs: \(codecs)")

--- a/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
+++ b/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
@@ -17,6 +17,10 @@ import Multiaddr
 extension Multiaddr {
 
     /// Extracts the address, port and protocol version from a Multiaddr if it is a valid TCP address
+    ///
+    /// The `address` may be a literal IP (`/ip4`, `/ip6`) or a hostname (`/dns`, `/dns4`, `/dns6`). Hostnames are
+    /// left unresolved here; the dialer passes them to NIO's `connect(host:port:)`, which performs the A/AAAA
+    /// lookup at connection time.
     public var tcpAddress: (address: String, port: Int, ip4: Bool)? {
         var host: String? = nil
         var port: Int? = nil
@@ -33,15 +37,21 @@ extension Multiaddr {
 
         for address in self.addresses {
             switch address.codec {
-            case .ip4:
+            case .ip4, .dns4:
                 if let h = address.addr {
                     host = h
                     isIP4 = true
                 }
-            case .ip6:
+            case .ip6, .dns6:
                 if let h = address.addr {
                     host = h
                     isIP4 = false
+                }
+            case .dns:
+                // `/dns` may resolve to either family; treat it as dialable and let NIO pick.
+                if let h = address.addr {
+                    host = h
+                    isIP4 = true
                 }
             case .tcp:
                 if let pStr = address.addr, let p = Int(pStr) {
@@ -62,6 +72,9 @@ extension Multiaddr {
     }
 
     /// Extracts the address, port and protocol version from a Multiaddr if it is a valid UDP address
+    ///
+    /// As with ``tcpAddress``, the `address` may be a literal IP or an unresolved hostname (`/dns`, `/dns4`,
+    /// `/dns6`) that the dialer resolves at connection time.
     public var udpAddress: (address: String, port: Int, ip4: Bool)? {
         var host: String? = nil
         var port: Int? = nil
@@ -78,15 +91,21 @@ extension Multiaddr {
 
         for address in self.addresses {
             switch address.codec {
-            case .ip4:
+            case .ip4, .dns4:
                 if let h = address.addr {
                     host = h
                     isIP4 = true
                 }
-            case .ip6:
+            case .ip6, .dns6:
                 if let h = address.addr {
                     host = h
                     isIP4 = false
+                }
+            case .dns:
+                // `/dns` may resolve to either family; treat it as dialable and let NIO pick.
+                if let h = address.addr {
+                    host = h
+                    isIP4 = true
                 }
             case .udp:
                 if let pStr = address.addr, let p = Int(pStr) {

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -16,42 +16,47 @@ import LibP2P
 import Testing
 
 extension LibP2PTests {
-    @Test("Ensure tcpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
-    func tcpAddressTests() throws {
-        let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
-        let addresses = [
-            "/dns/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
-            "/dns4/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
-            "/dns6/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
-            "/ip4/1.2.3.4/tcp/4001/p2p/\(peer)",
-            "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)",
-        ]
-
-        for address in addresses {
-            #expect(throws: Never.self) {
-                let ma = try Multiaddr(address)
-                #expect(ma.tcpAddress != nil)
-                #expect(ma.tcpAddress?.port == 4001)
+    
+    @Suite("AddressHelperTests")
+    struct AddressHelperTests {
+    
+        @Test("Ensure tcpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
+        func tcpAddressTests() throws {
+            let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+            let addresses = [
+                "/dns/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+                "/dns4/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+                "/dns6/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+                "/ip4/1.2.3.4/tcp/4001/p2p/\(peer)",
+                "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)",
+            ]
+            
+            for address in addresses {
+                #expect(throws: Never.self) {
+                    let ma = try Multiaddr(address)
+                    #expect(ma.tcpAddress != nil)
+                    #expect(ma.tcpAddress?.port == 4001)
+                }
             }
         }
-    }
-
-    @Test("Ensure udpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
-    func udpAddressTests() throws {
-        let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
-        let addresses = [
-            "/dns/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
-            "/dns4/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
-            "/dns6/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
-            "/ip4/147.75.87.27/udp/4001/quic-v1/p2p/\(peer)",
-            "/ip6/2604:1380:4602:5c00::3/udp/4001/quic-v1/p2p/\(peer)",
-        ]
-
-        for address in addresses {
-            #expect(throws: Never.self) {
-                let ma = try Multiaddr(address)
-                #expect(ma.udpAddress != nil)
-                #expect(ma.udpAddress?.port == 4001)
+        
+        @Test("Ensure udpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
+        func udpAddressTests() throws {
+            let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+            let addresses = [
+                "/dns/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+                "/dns4/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+                "/dns6/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+                "/ip4/147.75.87.27/udp/4001/quic-v1/p2p/\(peer)",
+                "/ip6/2604:1380:4602:5c00::3/udp/4001/quic-v1/p2p/\(peer)",
+            ]
+            
+            for address in addresses {
+                #expect(throws: Never.self) {
+                    let ma = try Multiaddr(address)
+                    #expect(ma.udpAddress != nil)
+                    #expect(ma.udpAddress?.port == 4001)
+                }
             }
         }
     }

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -24,9 +24,9 @@ extension LibP2PTests {
             "/dns4/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
             "/dns6/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
             "/ip4/1.2.3.4/tcp/4001/p2p/\(peer)",
-            "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)"
+            "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)",
         ]
-        
+
         for address in addresses {
             #expect(throws: Never.self) {
                 let ma = try Multiaddr(address)

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2P
+import Testing
+
+extension LibP2PTests {
+    @Test("Ensure tcpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
+    func tcpAddressTests() throws {
+        let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+        let addresses = [
+            "/dns/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+            "/dns4/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+            "/dns6/sv15.bootstrap.libp2p.io/tcp/4001/p2p/\(peer)",
+            "/ip4/1.2.3.4/tcp/4001/p2p/\(peer)",
+            "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)"
+        ]
+        
+        for address in addresses {
+            #expect(throws: Never.self) {
+                let ma = try Multiaddr(address)
+                #expect(ma.tcpAddress != nil)
+                #expect(ma.tcpAddress?.port == 4001)
+            }
+        }
+    }
+}

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -16,10 +16,10 @@ import LibP2P
 import Testing
 
 extension LibP2PTests {
-    
+
     @Suite("AddressHelperTests")
     struct AddressHelperTests {
-    
+
         @Test("Ensure tcpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
         func tcpAddressTests() throws {
             let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
@@ -30,7 +30,7 @@ extension LibP2PTests {
                 "/ip4/1.2.3.4/tcp/4001/p2p/\(peer)",
                 "/ip6/2604:1380:4602:5c00::3/tcp/4001/p2p/\(peer)",
             ]
-            
+
             for address in addresses {
                 #expect(throws: Never.self) {
                     let ma = try Multiaddr(address)
@@ -39,7 +39,7 @@ extension LibP2PTests {
                 }
             }
         }
-        
+
         @Test("Ensure udpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
         func udpAddressTests() throws {
             let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
@@ -50,7 +50,7 @@ extension LibP2PTests {
                 "/ip4/147.75.87.27/udp/4001/quic-v1/p2p/\(peer)",
                 "/ip6/2604:1380:4602:5c00::3/udp/4001/quic-v1/p2p/\(peer)",
             ]
-            
+
             for address in addresses {
                 #expect(throws: Never.self) {
                     let ma = try Multiaddr(address)

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -35,7 +35,7 @@ extension LibP2PTests {
             }
         }
     }
-    
+
     @Test("Ensure udpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
     func udpAddressTests() throws {
         let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"

--- a/Tests/LibP2PTests/AddressTests.swift
+++ b/Tests/LibP2PTests/AddressTests.swift
@@ -35,4 +35,24 @@ extension LibP2PTests {
             }
         }
     }
+    
+    @Test("Ensure udpAddress parses dns, dns4, dns6, ip4 and ip6 Multiaddr's")
+    func udpAddressTests() throws {
+        let peer = "QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+        let addresses = [
+            "/dns/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+            "/dns4/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+            "/dns6/sv15.bootstrap.libp2p.io/udp/4001/quic-v1/p2p/\(peer)",
+            "/ip4/147.75.87.27/udp/4001/quic-v1/p2p/\(peer)",
+            "/ip6/2604:1380:4602:5c00::3/udp/4001/quic-v1/p2p/\(peer)",
+        ]
+
+        for address in addresses {
+            #expect(throws: Never.self) {
+                let ma = try Multiaddr(address)
+                #expect(ma.udpAddress != nil)
+                #expect(ma.udpAddress?.port == 4001)
+            }
+        }
+    }
 }


### PR DESCRIPTION
### What?
This PR enables the `dns`, `dns4` and `dns6` `multicodecs` within our TCP dialer. Previously our `tcpAddress` helper was discarding non-literal ip addresses, but `swift-nio`s tcp stack resolves A/AAAA dns names on connection, so let's use it.

### Changes
- Updated `tcpAddress` and `udpAddress` helper methods to parse `dns`, `dns4` and `dns6` `multiaddr` hosts correctly, which allows our dial to proceed, as opposed to erroring with an 'unable to dial multiaddr' error. 

### Pending Issues
We can dial `/dns/sv15.bootstrap.libp2p.io/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN` but this address won't be saved in our PeerStore, instead we save the resolved literal IP address. We should probably be saving both (at least caching the resolve) so that we can query on the address for open connections to the peer using the `multiaddr`. Right now we can query for connections to the peer using the `PeerID` so it's not a huge issue.