### PR TITLE
Fix withApp Testing Helper

### DIFF
--- a/Sources/LibP2PTesting/withApp.swift
+++ b/Sources/LibP2PTesting/withApp.swift
@@ -40,18 +40,25 @@ import LibP2P
 @discardableResult
 public func withApp<T>(
     peerID: KeyPairFile = .ephemeral(),
+    autoStart: Bool = true,
     configure: ((Application) async throws -> Void)? = nil,
     _ test: (Application) async throws -> T
 ) async throws -> T {
     let app = try await Application.make(.testing, peerID: peerID)
     let result: T
     do {
+        // Configure the app (if a configuration is present)
         try await configure?(app)
+        // Start the app
+        if autoStart { try await app.startup() }
+        // Run the body / test
         result = try await test(app)
     } catch {
+        // Shutdown
         try? await app.asyncShutdown()
         throw error
     }
+    // Shutdown
     try await app.asyncShutdown()
     return result
 }
@@ -74,7 +81,8 @@ public func withApp<T>(
 @discardableResult
 public func withApp<T>(
     peerID: KeyPairFile = .ephemeral(),
+    autoStart: Bool = true,
     _ test: (Application) async throws -> T
 ) async throws -> T {
-    try await withApp(peerID: peerID, configure: nil, test)
+    try await withApp(peerID: peerID, autoStart: autoStart, configure: nil, test)
 }

--- a/Tests/LibP2PTests/ConnectionEventTests.swift
+++ b/Tests/LibP2PTests/ConnectionEventTests.swift
@@ -68,8 +68,6 @@ extension LibP2PTests {
         @Test("Application fires `connected` with the opened connection")
         func testConnectedEventFires() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let received = NIOLockedValueBox<[UUID]>([])
                 app.events.on(
@@ -91,8 +89,6 @@ extension LibP2PTests {
         @Test("Application fires `disconnected` with the connection and (nil) peer")
         func testDisconnectedEventFires() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let received = NIOLockedValueBox<(id: UUID, peerWasNil: Bool)?>(nil)
                 app.events.on(
@@ -116,8 +112,6 @@ extension LibP2PTests {
         @Test("Application fires `upgraded` with the upgraded connection")
         func testUpgradedEventFires() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let received = NIOLockedValueBox<[UUID]>([])
                 app.events.on(
@@ -139,8 +133,6 @@ extension LibP2PTests {
         @Test("Application fires `remotePeer` carrying the identified peer")
         func testRemotePeerEventFires() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let peer = try PeerID(.Ed25519)
                 let subscriber = Subscriber()
                 let received = NIOLockedValueBox<String?>(nil)
@@ -164,8 +156,6 @@ extension LibP2PTests {
         @Test("Application fires `openedStream` and `closedStream` with the stream")
         func testStreamOpenedAndClosedEventsFire() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let opened = NIOLockedValueBox<[UInt64]>([])
                 let closed = NIOLockedValueBox<[UInt64]>([])
@@ -209,7 +199,7 @@ extension LibP2PTests {
 
         @Test("Events posted while the application is not running are dropped")
         func testEventsDroppedWhenApplicationNotRunning() async throws {
-            try await withApp { app in
+            try await withApp(autoStart: false) { app in
                 // Deliberately do NOT start the app: `isRunning` is false, so `post` must drop the event.
                 #expect(app.isRunning == false)
 
@@ -242,8 +232,6 @@ extension LibP2PTests {
         @Test("Closing a running connection's channel publishes `disconnected`")
         func testChannelCloseFiresDisconnectedEvent() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let received = NIOLockedValueBox<[UUID]>([])
                 app.events.on(
@@ -287,8 +275,6 @@ extension LibP2PTests {
         @Test("`unregister` stops further callback delivery to that owner")
         func testUnregisterStopsDelivery() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let subscriber = Subscriber()
                 let count = NIOLockedValueBox<Int>(0)
                 app.events.on(
@@ -321,8 +307,6 @@ extension LibP2PTests {
         @Test("`subscribe(to:)` delivers matching events and terminates on cancellation")
         func testAsyncStreamDeliversAndTerminates() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let received = NIOLockedValueBox<[UUID]>([])
                 let terminated = NIOLockedValueBox<Bool>(false)
                 let stream = app.events.subscribe(to: [.connected])
@@ -353,8 +337,6 @@ extension LibP2PTests {
         @Test("A terminated `subscribe(to:)` stream stops receiving events (the AsyncStream analogue of `unregister`)")
         func testAsyncStreamStopsDeliveryAfterTermination() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let received = NIOLockedValueBox<[UUID]>([])
                 let stream = app.events.subscribe(to: [.connected])
 
@@ -397,8 +379,6 @@ extension LibP2PTests {
         func testEventsAreIsolatedPerApplication() async throws {
             try await withApp { appA in
                 try await withApp { appB in
-                    try await appA.startup()
-                    try await appB.startup()
 
                     let subscriberA = Subscriber()
                     let subscriberB = Subscriber()
@@ -456,8 +436,6 @@ extension LibP2PTests {
         @Test("A slow / non-responsive consumer does not block other subscribers")
         func testSlowConsumerDoesNotBlockOthers() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 // A non-responsive AsyncStream consumer: subscribed but never iterated. Its bounded buffer just
                 // fills and drops its own oldest events; yielding to it never blocks `post`.
                 let stalledStream = app.events.subscribe(to: [.connected])
@@ -537,8 +515,6 @@ extension LibP2PTests {
         )
         func testHighVolumeStaysBoundedAndDeinitializes() async throws {
             try await withApp { app in
-                try await app.startup()
-
                 let callbackSubscribers = 100
                 let fastStreamSubscribers = 100
                 let slowStreamSubscribers = 10
@@ -670,8 +646,6 @@ extension LibP2PTests {
                 app.eventbus.use(.default(bufferSize: bufferSize))
             }
             try await withApp(configure: configuration) { app in
-                try await app.startup()
-
                 // Register the subscriber, then post far more than the buffer WITHOUT draining, so the stream
                 // buffers as it goes and keeps only the newest `bufferSize` events.
                 let stream = app.events.subscribe(to: [.connected])

--- a/Tests/LibP2PTests/LibP2PTests.swift
+++ b/Tests/LibP2PTests/LibP2PTests.swift
@@ -117,7 +117,7 @@ struct LibP2PTests {
             #expect(app.logger.label.count == 26)
         }
     }
-    
+
     @Test func testWithAppDontAutoStart() async throws {
         try await withApp(autoStart: false) { app in
             #expect(app.isRunning == false)

--- a/Tests/LibP2PTests/LibP2PTests.swift
+++ b/Tests/LibP2PTests/LibP2PTests.swift
@@ -106,12 +106,22 @@ struct LibP2PTests {
 
     @Test func testWithApp() async throws {
         try await withApp { app in
+            #expect(app.isRunning == true)
             #expect(app.environment == Environment.testing)
             #expect(app.peerID.type == .isPrivate)
             #expect(app.peerID.keyPair?.keyType == .ed25519)
             #expect(app.listenAddresses.isEmpty)
             #expect(app.logger.label.hasPrefix("libp2p.application"))
+            // The above prefix with the first 6 chars of our PeerID
+            // ex: libp2p.application[D6e3qy]
             #expect(app.logger.label.count == 26)
+        }
+    }
+    
+    @Test func testWithAppDontAutoStart() async throws {
+        try await withApp(autoStart: false) { app in
+            #expect(app.isRunning == false)
+            #expect(app.environment == Environment.testing)
         }
     }
 
@@ -152,10 +162,6 @@ struct LibP2PTests {
         }
 
         try await withApp(configure: configure) { app in
-            // Actually run the app so the TCP server binds its
-            // socket; only then does port 0 get resolved to an OS-assigned port.
-            try await app.startup()
-
             // Fetch the address from the TCP server directly
             let localAddress = try #require(app.servers.server(for: TCPServer.self)?.listeningAddress)
             guard let tcp = localAddress.tcpAddress else {
@@ -203,9 +209,6 @@ struct LibP2PTests {
         }
 
         try await withApp(configure: configure) { app in
-            // Actually run the `serve` command so the TCP server binds its socket.
-            try await app.startup()
-
             // Fetch the address from the app's listenAddresses param
             let listenAddress = try #require(app.listenAddresses.first?.tcpAddress)
             #expect(listenAddress.address == "127.0.0.1")
@@ -253,9 +256,6 @@ struct LibP2PTests {
         }
 
         try await withApp(configure: configure) { app in
-            // Actually run the `serve` command so the TCP server binds its socket.
-            try await app.startup()
-
             // The address fetched from the TCPServer is the literal address we define (0.0.0.0:3022)
             let localAddress = try #require(app.servers.server(for: TCPServer.self)?.listeningAddress)
             guard let tcp = localAddress.tcpAddress else {


### PR DESCRIPTION
### What?
The `withApp` testing helper didn't start the app before running the tests body, this caused every consumer of the helper to have to explicitly call `try await app.startup()` in every test. So now, we handle starting the app automatically unless `autoStart` is set to false at the call site. 

### How to use
```swift
@Test func testWithApp() async throws {
    try await withApp { app in
        #expect(app.isRunning == true)
        #expect(app.environment == Environment.testing)
    }
}
    
@Test func testWithAppDontAutoStart() async throws {
    try await withApp(autoStart: false) { app in
        #expect(app.isRunning == false)
        #expect(app.environment == Environment.testing)
    }
}
```