### PR TITLE
TCP Server Listen Event

### DIFF
--- a/Sources/LibP2P/Servers/Application+Server.swift
+++ b/Sources/LibP2P/Servers/Application+Server.swift
@@ -26,29 +26,31 @@ extension Application {
         self.servers.use(serverProvider)
     }
 
-    //    public var listenAddresses:[Multiaddr] {
-    //        self.servers.allServers.reduce(into: Array<Multiaddr>()) { partialResult, server in
-    //            partialResult.append(server.listeningAddress)
-    //        }
-    //    }
-
     public var listenAddresses: [Multiaddr] {
         self.servers.allServers.reduce(into: [Multiaddr]()) { partialResult, server in
             partialResult.append(server.listeningAddress)
-        }.flatMap { ma -> [Multiaddr] in
-            // Expand an unspecified (`0.0.0.0`) bind address into one concrete
-            // multiaddr per non-loopback interface, mirroring rust-libp2p's
-            // transport-level `if_watch` expansion, so the wildcard never
-            // reaches the address-advertisement path. (The previous behavior
-            // swapped only the hardcoded `en0` interface and silently leaked
-            // raw `0.0.0.0` on any host whose primary interface wasn't `en0` —
-            // e.g. Wi-Fi/`en1`.) Never returns empty for a bound server, so
-            // callers that need `listenAddresses.first` keep a usable address.
-            guard let tcp = ma.tcpAddress, tcp.address == "0.0.0.0" else { return [ma] }
-            let interfaceIPs = self.getAllSystemAddresses()
-            guard !interfaceIPs.isEmpty else { return [ma] }
-            return interfaceIPs.compactMap { try? ma.swap(address: $0, forCodec: .ip4) }
-        }
+        }.flatMap { self.expandingUnspecified($0) }
+    }
+
+    /// Expands an unspecified (`0.0.0.0`) bind address into one concrete
+    /// multiaddr per non-loopback interface, so the wildcard never reaches the
+    /// address-advertisement path.
+    ///
+    /// Returns `[ma]` unchanged when the address isn't an IPv4 wildcard or when
+    /// interface enumeration turns up nothing, so this never returns empty for
+    /// a bound server and callers that need `.first` keep a usable address.
+    ///
+    /// - Note: Deliberately matched against `"0.0.0.0"` rather than
+    ///   ``Multiaddr/isUnspecifiedAddress``, which also matches the IPv6
+    ///   wildcard `::`. `getAllSystemAddresses()` returns IPv4 only, and
+    ///   `swap(address:forCodec: .ip4)` is a no-op on a multiaddr with no `ip4`
+    ///   component — so an IPv6 wildcard would expand into N copies of itself.
+    ///   IPv6 wildcard expansion remains unimplemented.
+    func expandingUnspecified(_ ma: Multiaddr) -> [Multiaddr] {
+        guard let tcp = ma.tcpAddress, tcp.address == "0.0.0.0" else { return [ma] }
+        let interfaceIPs = self.getAllSystemAddresses()
+        guard !interfaceIPs.isEmpty else { return [ma] }
+        return interfaceIPs.compactMap { try? ma.swap(address: $0, forCodec: .ip4) }
     }
 
     // MARK: - Advertised addresses

--- a/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
+++ b/Sources/LibP2P/Transports/TCP/Server/TCPServer.swift
@@ -208,7 +208,7 @@ public final class TCPServer: Server, @unchecked Sendable {
             addressDescription = "unix: \(socketPath)"
         }
 
-        self.configuration.logger.notice("TCP Server starting on \(addressDescription)")
+        self.configuration.logger.debug("TCP Initialized on \(addressDescription)")
 
         // start the actual TCPServer
         self.connection = try TCPServerConnection.start(
@@ -219,6 +219,21 @@ public final class TCPServer: Server, @unchecked Sendable {
         ).wait()
 
         self.didStart = true
+
+        if let la = self.localAddress {
+            self.configuration.logger.notice("TCP Server started on \(la.description)")
+            if let ma = try? la.toMultiaddr(proto: .tcp) {
+                // Expand our host into one concrete address per routable interface so
+                // `.listen` subscribers never observe a wildcard.
+                for address in self.application.expandingUnspecified(ma) {
+                    self.application.events.post(
+                        .listen(self.application.peerID.b58String, address)
+                    )
+                }
+            }
+        } else {
+            self.configuration.logger.warning("TCP Server started without a socket")
+        }
     }
 
     public func shutdown() {

--- a/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
+++ b/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
@@ -130,7 +130,6 @@ extension SocketAddress {
     public func toMultiaddr(proto: MultiaddrProtocol = .tcp) throws -> Multiaddr {
         var ma: Multiaddr
         if let ip = self.ipAddress {
-            /// - TODO: Determine if ip4 or ip6
             switch self.protocol {
             case .inet:
                 ma = try Multiaddr(.ip4, address: ip)
@@ -139,14 +138,6 @@ extension SocketAddress {
             default:
                 throw NSError(domain: "Failed to convert SocketAddress to Multiaddr", code: 0, userInfo: nil)
             }
-            //            if self.description.hasPrefix("[IPv6]") {
-            //                ma = try Multiaddr(.ip6, address: ip)
-            //            } else if self.description.hasPrefix("[IPv4]") {
-            //                ma = try Multiaddr(.ip4, address: ip)
-            //            } else {
-            //                throw NSError(domain: "Failed to convert SocketAddress to Multiaddr", code: 0, userInfo: nil)
-            //            }
-
             if let port = self.port {
                 switch proto {
                 case .tcp:
@@ -158,7 +149,6 @@ extension SocketAddress {
                     ma = try ma.encapsulate(proto: proto, address: "\(port)")
                 }
             }
-
         } else if let path = self.pathname {
             ma = try Multiaddr(.unix, address: path)
         } else {


### PR DESCRIPTION
### What?
The TCP Server will now emit a `.listen` event upon starting. The posted `MultiAddr` will be an expanded ipv4 address when the server was started with the 0.0.0.0 wildcard address.