### PR TITLE
Connection Manager Work

### DIFF
--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -39,6 +39,9 @@ extension Application {
     }
 
     public struct Connections: Sendable {
+        /// The default time a new Connection is given to complete its upgrade before being closed
+        public static let defaultUpgradeTimeout: TimeAmount = .seconds(15)
+
         public enum Errors: Error {
             case notImplementedYet
             case invalidProtocolNegotatied
@@ -140,6 +143,13 @@ extension Application {
 
         public func setIdleTimeout(_ timeout: TimeAmount) {
             self.storage.manager.withLockedValue { $0?.setIdleTimeout(timeout) }
+        }
+
+        /// Limits the time a new Connection is given to complete its upgrade before being closed
+        public func setUpgradeTimeout(_ timeout: TimeAmount) {
+            self.storage.manager.withLockedValue { manager in
+                (manager as? BasicInMemoryConnectionManager)?.setUpgradeTimeout(timeout)
+            }
         }
 
         /// Coalesces concurrent cold dials to the same address into a single connection.

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -112,6 +112,12 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
     /// Connection Pruning Task
     private var pruneTask: Scheduled<Void>? = nil
+    /// Completed once the prune chain kicked off by ``pruneTask`` has actually finished, so callers of
+    /// ``debouncedPrune()`` can await the pruning rather than merely the scheduled task firing.
+    ///
+    /// - Important: Whoever drops this promise must complete it first — a deallocated, uncompleted
+    ///   `EventLoopPromise` trips NIO's leaked-promise `fatalError` in debug builds.
+    private var prunePromise: EventLoopPromise<Void>? = nil
     private let pruneDebounceValue: TimeAmount = .milliseconds(100)
 
     private enum State {
@@ -505,6 +511,8 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     private func cancelPruneTask() {
         self.pruneTask?.cancel()
         self.pruneTask = nil
+        self.prunePromise?.succeed(())
+        self.prunePromise = nil
     }
 
     /// Cancels every scheduled task this manager owns and drops the bookkeeping that goes with them.
@@ -531,46 +539,58 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     private func pruneConnectionHistory(maxEntries: Int) -> EventLoopFuture<Void> {
         self.eventLoop.submit {
             if self.connectionHistory.count > maxEntries {
-                for _ in (0..<self.connectionHistory.count - maxEntries) {
-                    if let randEntry = self.connectionHistory.randomElement()?.key {
-                        self.connectionHistory.removeValue(forKey: randEntry)
-                    }
+                // Evict the peers we heard from longest ago, oldest first.
+                let staleFirst = self.connectionHistory.sorted { lhs, rhs in
+                    Self.lastSeen(in: lhs.value) < Self.lastSeen(in: rhs.value)
+                }
+                for entry in staleFirst.prefix(self.connectionHistory.count - maxEntries) {
+                    self.connectionHistory.removeValue(forKey: entry.key)
                 }
             }
             for (key, value) in self.connectionHistory {
-                if value.count > 10 {
-                    self.connectionHistory.updateValue(Array(value.suffix(10)), forKey: key)
+                if value.count > maxEntries {
+                    self.connectionHistory.updateValue(Array(value.suffix(maxEntries)), forKey: key)
                 }
             }
         }
     }
 
-    private func debouncedPrune() -> EventLoopFuture<Void> {
+    /// Schedules a prune, coalescing calls that arrive inside the debounce window.
+    /// - Note: `internal` rather than `private` only so tests can await a prune directly.
+    func debouncedPrune() -> EventLoopFuture<Void> {
         self.eventLoop.flatSubmit {
             guard self.application.isRunning, !self.application.didShutdown, self.state == .running else {
                 self.cancelPruneTask()
                 return self.eventLoop.makeSucceededVoidFuture()
             }
-            guard self.pruneTask == nil else {
-                return self.eventLoop.makeSucceededVoidFuture()
+            // A prune is already pending — join it rather than scheduling a second one.
+            if let pending = self.prunePromise {
+                return pending.futureResult
             }
-            let task = self.eventLoop.scheduleTask(
-                in: self.pruneDebounceValue,
-                { [weak self] in
-                    guard let self = self, self.application.isRunning, !self.application.didShutdown else { return }
-                    return self.pruneClosedConnections().flatMap {
-                        self.pruneOldConnections().flatMap {
-                            self.pruneConnectionHistory(maxEntries: self.maxConnectionHistoryCount).map {
-                                self.logger.debug("\(self.connections.count) / \(self.maxPeers) Connections")
-                            }
-                        }
-                    }.whenComplete { _ in
-                        self.pruneTask = nil
-                    }
+
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self.prunePromise = promise
+
+            // The promise is captured strongly so it is always completable, even if the manager is
+            // gone by the time the task fires; `self` stays weak so a pending prune doesn't keep the
+            // manager alive.
+            self.pruneTask = self.eventLoop.scheduleTask(in: self.pruneDebounceValue) { [weak self] in
+                guard let self = self, self.application.isRunning, !self.application.didShutdown else {
+                    promise.succeed(())
+                    return
                 }
-            )
-            self.pruneTask = task
-            return task.futureResult
+                self.pruneClosedConnections().flatMap {
+                    self.pruneOldConnections()
+                }.flatMap {
+                    self.pruneConnectionHistory(maxEntries: self.maxConnectionHistoryCount)
+                }.whenComplete { result in
+                    self.logger.debug("\(self.connections.count) / \(self.maxPeers) Connections")
+                    self.pruneTask = nil
+                    self.prunePromise = nil
+                    promise.completeWith(result)
+                }
+            }
+            return promise.futureResult
         }
     }
 

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -39,7 +39,17 @@ extension Application.Connections.Provider {
     }
 }
 
-class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
+/// The default, in-memory `ConnectionManager`.
+///
+/// ### Concurrency
+///
+/// Every mutable property on this class is confined to ``eventLoop`` therefore
+/// - Public entry points must hop
+/// - Private helpers assume they are already on the eventloop
+///
+/// - Note:
+/// `Connection.status` is the known exception, fixing it requires changes to `ConnectionStats`
+final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
 
     private let application: Application
     /// A mapping of all connections we are currently managing
@@ -138,7 +148,10 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
     }
 
     func setIdleTimeout(_ timeout: TimeAmount) {
-        self.idleTimeout = timeout
+        self.eventLoop.execute {
+            self.idleTimeout = timeout
+            self.logger.info("Idle Timeout updated to \(timeout.seconds) seconds")
+        }
     }
 
     /// Updates the window a Connection is given to complete its upgrade.
@@ -190,8 +203,8 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
     }
 
     func addConnection(_ connection: Connection, on loop: EventLoop?) -> EventLoopFuture<Void> {
-        guard self.state == .running else { return self.eventLoop.makeFailedFuture(Errors.tooManyPeers) }
-        return eventLoop.submit { () in
+        eventLoop.submit { () in
+            guard self.state == .running else { throw Errors.shuttingDown }
             if connection.direction == .inbound {
                 /// Allow inbound connections up until maxConnections - buffer  ( 100 - 20 )
                 guard self.connections.count < self.maxPeers - self.buffer else {
@@ -319,21 +332,31 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
         }
     }
 
+    /// Closes every managed Connection and puts the manager into its terminal `.shuttingDown` state.
+    ///
+    /// The guard, the state transition and the drain all run on `eventLoop`: `state`'s `didSet`
+    /// asserts a single one-way transition, so reading and writing it off the loop would let two
+    /// concurrent callers both pass the guard and trip that assertion.
     func closeAllConnections() -> EventLoopFuture<Void> {
-        guard self.state == .running else { return self.eventLoop.makeSucceededVoidFuture() }
-        self.state = .shuttingDown
-        return connections.map {
-            $0.value.close()
-        }.flatten(on: eventLoop).always { _ in
-            for connection in self.connections {
-                guard let pid = connection.value.remotePeer else { return }
-                self.connectionHistory[pid.b58String, default: []].append(connection.value.stats)
+        self.eventLoop.flatSubmit {
+            guard self.state == .running else { return self.eventLoop.makeSucceededVoidFuture() }
+            self.state = .shuttingDown
+
+            /// Snapshot the connections up front. Closing them can re-enter our own bookkeeping (a
+            /// close posts `.disconnected`), and we need the same set again for the history append.
+            let closing = Array(self.connections.values)
+
+            return closing.map { $0.close() }.flatten(on: self.eventLoop).always { _ in
+                
+                for connection in closing {
+                    // Update our history for the remote peer if we have one
+                    if let pid = connection.remotePeer {
+                        self.connectionHistory[pid.b58String, default: []].append(connection.stats)
+                    }
+                }
+                self.connections = [:]
+                self.cancelAllScheduledTasks()
             }
-            self.connections = [:]
-            self.pruneTask?.cancel()
-            self.pruneTask = nil
-            for task in self.upgradeTimeouts.values { task.cancel() }
-            self.upgradeTimeouts = [:]
         }
     }
 
@@ -397,6 +420,9 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
         }
     }
 
+    /// The single point for unregistering a Connection
+    /// Archives the Connections stats and cleans its state.
+    /// Anything keyed by connection identity belongs here, so no cleanup path can forget it.
     private func removeConnectionFromList(id: UUID) -> EventLoopFuture<Void> {
         self.eventLoop.submit {
             if let c = self.connections.removeValue(forKey: id.uuidString) {
@@ -408,6 +434,47 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
             }
             self.connectionStreamCount.removeValue(forKey: id.uuidString)
             self.cancelUpgradeTimeout(for: id)
+            self.cancelIdleTimeout(for: id)
+        }
+    }
+
+    /// Cancels a Connection's pending idle-close task.
+    ///
+    /// Both of these used to be cleared only on the paths that scheduled them, so a Connection torn
+    /// down by any other route (a prune, a peer-initiated close) left its entries behind forever.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func cancelIdleTimeout(for id: UUID) {
+        if let task = self.connectionTimeouts.removeValue(forKey: id.uuidString) {
+            task.cancel()
+        }
+        self.alerts.removeValue(forKey: id)
+    }
+
+    /// Cancels the debounced prune task, if one is armed.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func cancelPruneTask() {
+        self.pruneTask?.cancel()
+        self.pruneTask = nil
+    }
+
+    /// Cancels every scheduled task this manager owns and drops the bookkeeping that goes with them.
+    /// Used on shutdown so nothing we scheduled outlives the manager.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func cancelAllScheduledTasks() {
+        self.cancelPruneTask()
+        for task in self.upgradeTimeouts.values { task.cancel() }
+        self.upgradeTimeouts = [:]
+        for task in self.connectionTimeouts.values { task.cancel() }
+        self.connectionTimeouts = [:]
+        self.alerts = [:]
+    }
+
+    /// The number of per-Connection scheduled tasks and bookkeeping entries currently held.
+    /// Exists so tests can assert that unregistering a Connection leaves nothing behind.
+    internal func perConnectionBookkeepingCount() -> EventLoopFuture<Int> {
+        self.eventLoop.submit {
+            self.upgradeTimeouts.count + self.connectionTimeouts.count + self.alerts.count
+                + self.connectionStreamCount.count
         }
     }
 
@@ -429,19 +496,15 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
     }
 
     private func debouncedPrune() -> EventLoopFuture<Void> {
-        guard self.application.isRunning && !self.application.didShutdown && self.state == .running else {
-            if let pt = self.pruneTask {
-                pt.cancel()
-                self.pruneTask = nil
+        self.eventLoop.flatSubmit {
+            guard self.application.isRunning, !self.application.didShutdown, self.state == .running else {
+                self.cancelPruneTask()
+                return self.eventLoop.makeSucceededVoidFuture()
             }
-            return self.eventLoop.makeSucceededVoidFuture()
-        }
-        return self.eventLoop.flatSubmit {
-            // self.logger.notice("Debouncing Prune");
             guard self.pruneTask == nil else {
                 return self.eventLoop.makeSucceededVoidFuture()
             }
-            self.pruneTask = self.eventLoop.scheduleTask(
+            let task = self.eventLoop.scheduleTask(
                 in: self.pruneDebounceValue,
                 { [weak self] in
                     guard let self = self, self.application.isRunning, !self.application.didShutdown else { return }
@@ -456,15 +519,19 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
                     }
                 }
             )
-            return self.pruneTask!.futureResult
+            self.pruneTask = task
+            return task.futureResult
         }
     }
 
+    /// - Note: EventBus callbacks are delivered on the bus's own drain `Task`, so this hops before reading `state`.
     func onDisconnectedNew(_ connection: Connection, peer: PeerID?) {
-        guard self.application.isRunning && !self.application.didShutdown else { return }
-        guard self.state == .running else { return }
-        debouncedPrune().whenComplete { res in
-            self.logger.trace("Done with debounced prune \(res)")
+        self.eventLoop.execute {
+            guard self.application.isRunning, !self.application.didShutdown else { return }
+            guard self.state == .running else { return }
+            self.debouncedPrune().whenComplete { res in
+                self.logger.trace("Done with debounced prune \(res)")
+            }
         }
     }
 
@@ -587,6 +654,8 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
         case tooManyPeers
         case connectionAlreadyExists
         case failedToCloseConnection
+        /// The ConnectionManager has begun shutting down and is no longer accepting Connections.
+        case shuttingDown
     }
 }
 

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -286,6 +286,10 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         self.upgradeTimeouts[key] = self.eventLoop.scheduleTask(in: timeout) { [weak self] in
             guard let self = self else { return }
             self.upgradeTimeouts.removeValue(forKey: key)
+            // Teardown closes everything anyway; don't race it or log alarming warnings while it runs.
+            guard self.application.isRunning, !self.application.didShutdown, self.state == .running else {
+                return
+            }
             /// The Connection may have already been closed and unregistered by another path
             guard let connection = self.connections[key] else { return }
             /// If the `.upgraded` event was missed (or raced us), the status is the source of truth
@@ -363,7 +367,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
             } else {
                 return conns
             }
-        }
+        }.hop(to: loop ?? eventLoop)
     }
 
     /// Closes every managed Connection and puts the manager into its terminal `.shuttingDown` state.

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -146,8 +146,8 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         }))
         self.eventBus.on(self, event: .upgraded({ [weak self] conn in self?.onUpgraded(conn) }))
         if ASCEnabled {
-            self.application.events.on(self, event: .openedStream(onOpenedStream))
-            self.application.events.on(self, event: .closedStream(onClosedStream))
+            self.eventBus.on(self, event: .openedStream({ [weak self] s in self?.onOpenedStream(s) }))
+            self.eventBus.on(self, event: .closedStream({ [weak self] s in self?.onClosedStream(s) }))
         } else {
             self.eventBus.on(self, event: .openedStream({ [weak self] s in self?.onOpenedStreamCounter(s) }))
         }

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -21,13 +21,18 @@ extension Application.Connections.Provider {
         }
     }
 
-    public static func `default`(maxConcurrentConnections: Int, ASCEnabled: Bool = true) -> Self {
+    public static func `default`(
+        maxConcurrentConnections: Int,
+        ASCEnabled: Bool = true,
+        upgradeTimeout: TimeAmount = Application.Connections.defaultUpgradeTimeout
+    ) -> Self {
         .init { app in
             app.connectionManager.use {
                 BasicInMemoryConnectionManager(
                     application: $0,
                     maxPeers: maxConcurrentConnections,
-                    ASCEnabled: ASCEnabled
+                    ASCEnabled: ASCEnabled,
+                    upgradeTimeout: upgradeTimeout
                 )
             }
         }
@@ -69,6 +74,16 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
     /// Idle Connection Timeout
     private var idleTimeout: TimeAmount = .seconds(3)
 
+    /// The amount of time a newly registered Connection is given to reach the `.upgraded` state.
+    ///
+    /// Connections are handed to us the moment their channel becomes active, well before the security
+    /// and muxer handshakes complete. A remote that connects and then goes silent would otherwise
+    /// occupy a slot indefinitely
+    private var upgradeTimeout: TimeAmount
+
+    /// Pending upgrade timeout tasks, keyed by the Connection's `id.uuidString`
+    private var upgradeTimeouts: [String: Scheduled<Void>] = [:]
+
     /// The inbound vs outbound buffer
     private var buffer: Int
 
@@ -84,7 +99,12 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
         didSet { precondition(oldValue == .running && state == .shuttingDown, "Invalid State Transition") }
     }
 
-    internal init(application: Application, maxPeers: Int = 50, ASCEnabled: Bool = false) {
+    internal init(
+        application: Application,
+        maxPeers: Int = 50,
+        ASCEnabled: Bool = false,
+        upgradeTimeout: TimeAmount = Application.Connections.defaultUpgradeTimeout
+    ) {
         self.application = application
         self.eventLoop = application.eventLoopGroup.next()
         self.logger = application.logger
@@ -94,9 +114,12 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
         self.connections = [:]
         self.maxPeers = maxPeers
         self.buffer = Int(Double(maxPeers) * 0.2)
+        self.upgradeTimeout = upgradeTimeout
 
         /// Subscribe to onDisconnect events
         self.application.events.on(self, event: .disconnected(onDisconnectedNew))
+        /// Subscribe to onUpgraded events so we can disarm a Connection's upgrade timeout
+        self.application.events.on(self, event: .upgraded(onUpgraded))
         if ASCEnabled {
             self.application.events.on(self, event: .openedStream(onOpenedStream))
             self.application.events.on(self, event: .closedStream(onClosedStream))
@@ -116,6 +139,17 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
 
     func setIdleTimeout(_ timeout: TimeAmount) {
         self.idleTimeout = timeout
+    }
+
+    /// Updates the window a Connection is given to complete its upgrade.
+    ///
+    /// - Note: Only Connections registered after this call observe the new value; timeouts already
+    ///   armed continue to run with the window that was in effect when they were scheduled.
+    func setUpgradeTimeout(_ timeout: TimeAmount) {
+        let _ = self.eventLoop.submit {
+            self.upgradeTimeout = timeout
+            self.logger.info("Upgrade Timeout updated to \(timeout.seconds) seconds")
+        }
     }
 
     func getConnections(on loop: EventLoop?) -> EventLoopFuture<[Connection]> {
@@ -182,10 +216,54 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
             guard self.connections[connection.id.uuidString] == nil else { throw Errors.connectionAlreadyExists }
             self.connections[connection.id.uuidString] = connection
             self.totalConnectionCounter += 1
+            /// Give the Connection a bounded window to finish upgrading before we reclaim its slot
+            self.armUpgradeTimeout(for: connection)
             /// Kick off a prune if we're close to our max peer count
             if self.connections.count > (self.maxPeers - self.buffer) { let _ = self.debouncedPrune() }
             return
         }.hop(to: loop ?? eventLoop)
+    }
+
+    // MARK: - Upgrade Timeout
+
+    /// Schedules the upgrade deadline for a freshly registered Connection.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func armUpgradeTimeout(for connection: Connection) {
+        let key = connection.id.uuidString
+        /// A Connection that's already upgraded (or beyond) doesn't need a deadline
+        guard connection.status != .upgraded, connection.status != .closing, connection.status != .closed else {
+            return
+        }
+        guard self.upgradeTimeouts[key] == nil else { return }
+        let timeout = self.upgradeTimeout
+        self.upgradeTimeouts[key] = self.eventLoop.scheduleTask(in: timeout) { [weak self] in
+            guard let self = self else { return }
+            self.upgradeTimeouts.removeValue(forKey: key)
+            /// The Connection may have already been closed and unregistered by another path
+            guard let connection = self.connections[key] else { return }
+            /// If the `.upgraded` event was missed (or raced us), the status is the source of truth
+            guard connection.status != .upgraded else { return }
+            self.logger.warning(
+                "Connection[\(key.prefix(5))][\(connection.remoteAddr?.description ?? "???")] failed to upgrade within \(timeout.seconds) seconds. Closing."
+            )
+            /// Close the stalled Connection and reclaim its slot
+            let _ = self.closeConnectionWithTimeout(id: connection.id)
+        }
+    }
+
+    /// Cancels a Connection's pending upgrade deadline, if one is still armed.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func cancelUpgradeTimeout(for id: UUID) {
+        if let task = self.upgradeTimeouts.removeValue(forKey: id.uuidString) {
+            task.cancel()
+        }
+    }
+
+    /// The Connection completed its security + muxer handshakes, so it no longer needs a deadline.
+    func onUpgraded(_ connection: Connection) {
+        let _ = self.eventLoop.submit {
+            self.cancelUpgradeTimeout(for: connection.id)
+        }
     }
 
     private func dumpConnectionMetricsRandomSample() {
@@ -254,6 +332,8 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
             self.connections = [:]
             self.pruneTask?.cancel()
             self.pruneTask = nil
+            for task in self.upgradeTimeouts.values { task.cancel() }
+            self.upgradeTimeouts = [:]
         }
     }
 
@@ -327,6 +407,7 @@ class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
                 self.logger.error("Failed to remove Connection from list.")
             }
             self.connectionStreamCount.removeValue(forKey: id.uuidString)
+            self.cancelUpgradeTimeout(for: id)
         }
     }
 

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -648,8 +648,15 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
                     existingTimeoutTask.cancel()
                 }
                 // Wait for the idleTimeout, if it's still at 0 after a second then we assume it's idle / unsused and we proceed to close it...
-                self.connectionTimeouts[connection.id.uuidString] = self.eventLoop.scheduleTask(in: self.idleTimeout) {
-                    if let alertEntry = self.alerts.removeValue(forKey: connection.id) {
+                // `self` and the connection are both held weakly, capturing the connection
+                // could pin it for the whole idle window after its last stream closed.
+                let id = connection.id
+                self.connectionTimeouts[id.uuidString] = self.eventLoop.scheduleTask(in: self.idleTimeout) {
+                    [weak self] in
+                    guard let self = self else { return }
+                    self.connectionTimeouts.removeValue(forKey: id.uuidString)
+
+                    if let alertEntry = self.alerts.removeValue(forKey: id) {
                         if Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970
                             > (self.idleTimeout.milliseconds * 0.0015)
                         {
@@ -659,18 +666,15 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
                             )
                         }
                     }
-                    if self.connectionStreamCount[connection.id.uuidString] == 0
-                        && connection.lastActive > self.idleTimeout
-                    {
+
+                    // Re-resolve the connection: it may already have been unregistered while we waited.
+                    guard let connection = self.connections[id.uuidString] as? AppConnection else { return }
+                    if self.connectionStreamCount[id.uuidString] == 0 && connection.lastActive > self.idleTimeout {
                         connection.close().whenComplete { _ in
                             self.logger.debug("Closed Connection using Automatic Reference Counting!")
                         }
-                        if let c = self.connections.removeValue(forKey: connection.id.uuidString) {
-                            if let pid = c.remotePeer {
-                                self.connectionHistory[pid.b58String, default: []].append(c.stats)
-                            }
-                        }
-                        self.connectionStreamCount.removeValue(forKey: connection.id.uuidString)
+                        // Route through the shared close point
+                        let _ = self.removeConnectionFromList(id: id)
                     }
                 }
 

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -206,23 +206,33 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         }.hop(to: loop ?? eventLoop)
     }
 
+    /// Our connectedness to `peer`.
+    ///
+    /// Attempts to classify our ability to connect to a given peer (returning .NotConnected, if we know nothing about them)
     func connectedness(peer: PeerID, on loop: EventLoop?) -> EventLoopFuture<Connectedness> {
         connectionsInvolvingPeer(peer: peer).map { conns -> Connectedness in
-            if conns.count > 0 {
+            if conns.contains(where: { $0.status != .closing && $0.status != .closed }) {
                 return .Connected
-            } else {
-                if let existing = self.connectionHistory[peer.b58String] {
-                    if let mostRecent = existing.last,
-                        mostRecent.timeline.history.contains(where: { $0.key == .upgraded })
-                    {
-                        return .CanConnect
-                    } else {
-                        return .CanNotConnect
-                    }
+            }
+
+            // Anything still registered has yet to be archived into `connectionHistory`, so consult it
+            // directly before falling back to the history.
+            if conns.contains(where: { $0.timeline[.upgraded] != nil }) {
+                return .CanConnect
+            }
+
+            if let existing = self.connectionHistory[peer.b58String] {
+                if let mostRecent = existing.last,
+                    mostRecent.timeline.history.contains(where: { $0.key == .upgraded })
+                {
+                    return .CanConnect
                 } else {
-                    return .NotConnected
+                    return .CanNotConnect
                 }
             }
+
+            // We've talked to this peer (a closing connection is still on file) but never upgraded.
+            return conns.isEmpty ? .NotConnected : .CanNotConnect
         }.hop(to: loop ?? eventLoop)
     }
 

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -406,10 +406,11 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         }
     }
 
+    /// Unregisters Connections that have already finished closing.
     private func pruneClosedConnections() -> EventLoopFuture<Void> {
         eventLoop.flatSubmit { () in
             self.connections.filter({ $0.value.status == .closed }).map {
-                self.closeConnectionWithTimeout(id: $0.value.id)
+                self.removeConnectionFromList(id: $0.value.id)
             }.flatten(on: self.eventLoop)
         }
     }

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -52,8 +52,7 @@ extension Application.Connections.Provider {
 final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendable {
 
     private let application: Application
-    /// A mapping of all connections we are currently managing
-    /// RemoteAddress (String) : [Connection]
+    /// Every Connection we are currently managing, keyed by `connection.id.uuidString`
     private var connections: [String: Connection]
 
     /// A dictionary keyed by the RemotePeer's b58String containing a list of ConnectionStats (one for each connection established to the peer)
@@ -64,7 +63,11 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
     /// Connection Stream ARC Counter
     private var connectionStreamCount: [String: Int] = [:]
+    /// Pending ARC style idle-close tasks, keyed by the Connection's `id.uuidString`
     private var connectionTimeouts: [String: Scheduled<Void>] = [:]
+    /// When each Connection went idle, used only to detect a slow-running ARC loop. Cleared alongside
+    /// the matching `connectionTimeouts` entry.
+    private var alerts: [UUID: Date] = [:]
 
     /// The max number of connections we can have open at any given time
     private var maxPeers: Int
@@ -77,9 +80,9 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
     // These params are used for Connection Pruning under heavy loads
     /// The minimum Idle connection time
-    private var minExpiration: Int = 3
+    private let minExpiration: Int = 3
     /// The maximum Idle connection time
-    private var maxExpiration: Int = 30
+    private let maxExpiration: Int = 30
 
     /// Idle Connection Timeout
     private var idleTimeout: TimeAmount = .seconds(3)
@@ -148,7 +151,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
         // Every subscription captures `self` weakly to avoid retain cycles
         self.eventBus.on(self, event: .disconnected({ [weak self] conn, peer in
-            self?.onDisconnectedNew(conn, peer: peer)
+            self?.onDisconnected(conn, peer: peer)
         }))
         self.eventBus.on(self, event: .upgraded({ [weak self] conn in self?.onUpgraded(conn) }))
         if ASCEnabled {
@@ -170,7 +173,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     }
 
     func setMaxConnections(_ maxConnections: Int) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             self.maxPeers = maxConnections
             self.buffer = Int(Double(maxConnections) * 0.2)
             self.logger.info("Max Connections updated to \(maxConnections)")
@@ -180,7 +183,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     func setIdleTimeout(_ timeout: TimeAmount) {
         self.eventLoop.execute {
             self.idleTimeout = timeout
-            self.logger.info("Idle Timeout updated to \(timeout.seconds) seconds")
+            self.logger.info("Idle Timeout updated to \(timeout.asSeconds) seconds")
         }
     }
 
@@ -189,15 +192,15 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     /// - Note: Only Connections registered after this call observe the new value; timeouts already
     ///   armed continue to run with the window that was in effect when they were scheduled.
     func setUpgradeTimeout(_ timeout: TimeAmount) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             self.upgradeTimeout = timeout
-            self.logger.info("Upgrade Timeout updated to \(timeout.seconds) seconds")
+            self.logger.info("Upgrade Timeout updated to \(timeout.asSeconds) seconds")
         }
     }
 
     func getConnections(on loop: EventLoop?) -> EventLoopFuture<[Connection]> {
         eventLoop.submit { () -> [Connection] in
-            self.connections.map { $0.value }
+            Array(self.connections.values)
         }.hop(to: loop ?? eventLoop)
     }
 
@@ -208,7 +211,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     func getBestConnectionForPeer(peer: PeerID, on loop: EventLoop?) -> EventLoopFuture<Connection?> {
         connectionsInvolvingPeer(peer: peer).map { connections -> Connection? in
             //Or some other check like ping / latency / last seen / etc...
-            connections.first(where: { $0.stats.status == .upgraded })
+            connections.first(where: { $0.status == .upgraded })
         }.hop(to: loop ?? eventLoop)
     }
 
@@ -252,7 +255,6 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
                         "Preventing new \(connection.direction) connection due to max connection limit reached \(self.connections.count)"
                     )
                     let _ = self.debouncedPrune()
-                    //self.dumpConnectionMetricsRandomSample()
                     throw Errors.tooManyPeers
                 }
             } else {
@@ -262,7 +264,6 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
                         "Preventing new \(connection.direction) connection due to max connection limit reached \(self.connections.count)"
                     )
                     let _ = self.debouncedPrune()
-                    //self.dumpConnectionMetricsRandomSample()
                     throw Errors.tooManyPeers
                 }
             }
@@ -301,10 +302,10 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
             /// If the `.upgraded` event was missed (or raced us), the status is the source of truth
             guard connection.status != .upgraded else { return }
             self.logger.warning(
-                "Connection[\(key.prefix(5))][\(connection.remoteAddr?.description ?? "???")] failed to upgrade within \(timeout.seconds) seconds. Closing."
+                "Connection[\(key.prefix(5))][\(connection.remoteAddr?.description ?? "???")] failed to upgrade within \(timeout.asSeconds) seconds. Closing."
             )
             /// Close the stalled Connection and reclaim its slot
-            let _ = self.closeConnectionWithTimeout(id: connection.id)
+            let _ = self.closeAndUnregister(id: connection.id)
         }
     }
 
@@ -318,31 +319,8 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
     /// The Connection completed its security + muxer handshakes, so it no longer needs a deadline.
     func onUpgraded(_ connection: Connection) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             self.cancelUpgradeTimeout(for: connection.id)
-        }
-    }
-
-    private func dumpConnectionMetricsRandomSample() {
-        let _ = eventLoop.submit {
-            self.logger.debug("Oldest 4 Connections")
-            self.logger.debug("Date: \(Date())")
-            let bcl: [AppConnection] = self.connections.compactMap { $0.value as? AppConnection }
-
-            for sample in bcl.sorted(by: { lhs, rhs in
-                lhs.lastActivity() < rhs.lastActivity()
-            }).prefix(4) {
-                self.logger.debug("\(sample.id) -> \(sample.lastActivity())")
-                if Date().timeIntervalSince1970 - sample.lastActivity().timeIntervalSince1970 > 5 {
-                    self.logger.debug("\(sample.description)")
-                }
-                //self.logger.notice("Last Active: \($0.lastActivity())")
-                //self.logger.notice("\($0.streamHistory)")
-                //self.logger.notice("Stream Count::\($0.streams.count)")
-                //for stream in $0.streams {
-                //    self.logger.notice("[\(stream.id)]\(stream.protocolCodec)::\(stream.direction)::\(stream.streamState)")
-                //}
-            }
         }
     }
 
@@ -359,14 +337,11 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         onlyMuxed: Bool = false,
         on loop: EventLoop?
     ) -> EventLoopFuture<[Connection]> {
-        //print("Current Connections")
-        //print(self.connections.map { $0.value.remoteAddr.description }.joined(separator: "\n") )
-        //print("-------------------")
         eventLoop.submit { () -> [Connection] in
-            let conns = self.connections.filter({
-                $0.value.remoteAddr == ma
-                    && ($0.value.status == .open || $0.value.status == .opening || $0.value.status == .upgraded)
-            }).map { $0.value }
+            let conns = self.connections.values.filter {
+                $0.remoteAddr == ma
+                    && ($0.status == .open || $0.status == .opening || $0.status == .upgraded)
+            }
 
             if onlyMuxed {
                 return conns.filter { $0.isMuxed }
@@ -406,28 +381,15 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
     private func connectionsInvolvingPeer(peer: PeerID) -> EventLoopFuture<[Connection]> {
         eventLoop.submit { () -> [Connection] in
-            self.connections.filter({ (elem) -> Bool in
-                elem.value.localPeer == peer || elem.value.remotePeer == peer
-            }).map { $0.value }
+            self.connections.values.filter { $0.localPeer == peer || $0.remotePeer == peer }
         }
     }
 
     /// Unregisters Connections that have already finished closing.
     private func pruneClosedConnections() -> EventLoopFuture<Void> {
         eventLoop.flatSubmit { () in
-            self.connections.filter({ $0.value.status == .closed }).map {
-                self.removeConnectionFromList(id: $0.value.id)
-            }.flatten(on: self.eventLoop)
-        }
-    }
-
-    /// Removes connections that have 0 streams open.
-    private func pruneConnections() -> EventLoopFuture<Void> {
-        eventLoop.flatSubmit { () in
-            self.connections.filter({
-                ($0.value.status == .upgraded || $0.value.status == .closing) && $0.value.streams.isEmpty
-            }).map {
-                self.closeConnectionWithTimeout(id: $0.value.id)
+            self.connections.values.filter { $0.status == .closed }.map {
+                self.removeConnectionFromList(id: $0.id)
             }.flatten(on: self.eventLoop)
         }
     }
@@ -440,26 +402,23 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
             )
             let expiration = (factor * Double(self.maxExpiration - self.minExpiration)) + Double(self.minExpiration)
             let expirationDate = Date().addingTimeInterval(-expiration)
-            let bcl: [AppConnection] = self.connections.compactMap { $0.value as? AppConnection }.filter {
+            let bcl: [AppConnection] = self.connections.values.compactMap { $0 as? AppConnection }.filter {
                 $0.lastActivity() < expirationDate
             }
-            guard bcl.count > 0 else { return self.eventLoop.makeSucceededVoidFuture() }
+            guard !bcl.isEmpty else { return self.eventLoop.makeSucceededVoidFuture() }
             self.logger.debug("Pruning \(bcl.count) Connections that are older than \(Int(expiration)) seconds")
             return bcl.map { conn in
-                //self.logger.notice("Closing Old Connection[\(conn.id)][\(conn.remoteAddr?.description ?? "???")][\(conn.remotePeer?.description ?? "???")]")
-                self.closeConnectionWithTimeout(id: conn.id)
+                self.closeAndUnregister(id: conn.id)
             }.flatten(on: self.eventLoop).always { _ in
                 if bcl.count > 1 { self.dumpConnectionManagerStats() }
             }
         }
     }
 
-    private func closeConnectionWithTimeout(id: UUID) -> EventLoopFuture<Void> {
+    /// Closes a Connection and unregisters it.
+    private func closeAndUnregister(id: UUID) -> EventLoopFuture<Void> {
         self.eventLoop.submit {
-            guard let connection = self.connections[id.uuidString] else {
-                //self.logger.warning("Failed to find connection with id: \(id.uuidString) in connection database.")
-                return
-            }
+            guard let connection = self.connections[id.uuidString] else { return }
             let _ = connection.close()
             let _ = self.removeConnectionFromList(id: id)
         }
@@ -595,7 +554,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     }
 
     /// - Note: EventBus callbacks are delivered on the bus's own drain `Task`, so this hops before reading `state`.
-    func onDisconnectedNew(_ connection: Connection, peer: PeerID?) {
+    func onDisconnected(_ connection: Connection, peer: PeerID?) {
         self.eventLoop.execute {
             guard self.application.isRunning, !self.application.didShutdown else { return }
             guard self.state == .running else { return }
@@ -606,18 +565,17 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     }
 
     func onOpenedStreamCounter(_ stream: LibP2PCore.Stream) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             self.totalStreamCounter += 1
         }
     }
 
     func onOpenedStream(_ stream: LibP2PCore.Stream) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             guard let connection = stream.connection else {
                 self.logger.error("New Stream doesn't have an associated connection")
                 return
             }
-            //self.logger.notice("ARC[\(connection.id.uuidString)]::Incrementing Stream Count")
             self.connectionStreamCount[connection.id.uuidString, default: 0] += 1
             self.totalStreamCounter += 1
             if let existingTimeoutTask = self.connectionTimeouts.removeValue(forKey: connection.id.uuidString) {
@@ -626,9 +584,8 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         }
     }
 
-    var alerts: [UUID: Date] = [:]
     func onClosedStream(_ stream: LibP2PCore.Stream) {
-        let _ = self.eventLoop.submit {
+        self.eventLoop.execute {
             guard let connection = stream.connection as? AppConnection else {
                 self.logger.error("Closed Stream doesn't have an associated connection")
                 return
@@ -638,7 +595,6 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
                 self.logger.error("Unbalanced Stream Open/Closed Count")
                 return
             }
-            //self.logger.notice("ARC[\(connection.id.uuidString)]::Decrementing Stream Count \(streamCount) - 1")
             if streamCount == 1 {
                 /// Decrement our stream count
                 self.connectionStreamCount[connection.id.uuidString] = 0
@@ -658,11 +614,11 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
 
                     if let alertEntry = self.alerts.removeValue(forKey: id) {
                         if Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970
-                            > (self.idleTimeout.milliseconds * 0.0015)
+                            > (self.idleTimeout.asMilliseconds * 0.0015)
                         {
                             self.logger.warning("🚨🚨🚨 ARC Running Slow!!! 🚨🚨🚨")
                             self.logger.warning(
-                                "\(self.idleTimeout.seconds) seconds took \(Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970)s"
+                                "\(self.idleTimeout.asSeconds) seconds took \(Date().timeIntervalSince1970 - alertEntry.timeIntervalSince1970)s"
                             )
                         }
                     }
@@ -727,17 +683,18 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     public enum Errors: Error {
         case tooManyPeers
         case connectionAlreadyExists
-        case failedToCloseConnection
         /// The ConnectionManager has begun shutting down and is no longer accepting Connections.
         case shuttingDown
     }
 }
 
 extension TimeAmount {
-    var milliseconds: Double {
+    /// This `TimeAmount` as a fractional count of milliseconds.
+    var asMilliseconds: Double {
         Double(self.nanoseconds) / 1_000_000
     }
-    var seconds: Double {
+    /// This `TimeAmount` as a fractional count of seconds.
+    var asSeconds: Double {
         Double(self.nanoseconds) / 1_000_000_000
     }
 }

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -150,9 +150,12 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         self.upgradeTimeout = upgradeTimeout
 
         // Every subscription captures `self` weakly to avoid retain cycles
-        self.eventBus.on(self, event: .disconnected({ [weak self] conn, peer in
-            self?.onDisconnected(conn, peer: peer)
-        }))
+        self.eventBus.on(
+            self,
+            event: .disconnected({ [weak self] conn, peer in
+                self?.onDisconnected(conn, peer: peer)
+            })
+        )
         self.eventBus.on(self, event: .upgraded({ [weak self] conn in self?.onUpgraded(conn) }))
         if ASCEnabled {
             self.eventBus.on(self, event: .openedStream({ [weak self] s in self?.onOpenedStream(s) }))
@@ -366,7 +369,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
             let closing = Array(self.connections.values)
 
             return closing.map { $0.close() }.flatten(on: self.eventLoop).always { _ in
-                
+
                 for connection in closing {
                     // Update our history for the remote peer if we have one
                     if let pid = connection.remotePeer {

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -477,6 +477,17 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         }
     }
 
+    /// The most recent moment on file across a peer's archived Connections, used to decide which peers
+    /// to evict from `connectionHistory` first.
+    ///
+    /// Entries are appended as Connections close, so the last one is the freshest. `Timeline`'s
+    /// individual timestamps are internal to `LibP2PCore`, so we read them through its public
+    /// `history` dictionary
+    private static func lastSeen(in history: [ConnectionStats]) -> Date {
+        guard let mostRecent = history.last else { return .distantPast }
+        return mostRecent.timeline.history.values.max() ?? .distantPast
+    }
+
     /// Cancels a Connection's pending idle-close task.
     ///
     /// Both of these used to be cleared only on the paths that scheduled them, so a Connection torn

--- a/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/DefaultConnectionManager.swift
@@ -94,6 +94,19 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
     /// Pending upgrade timeout tasks, keyed by the Connection's `id.uuidString`
     private var upgradeTimeouts: [String: Scheduled<Void>] = [:]
 
+    /// The EventBus we're subscribed to, resolved once at init.
+    ///
+    /// `deinit` must not reach it through `application.events`: this manager is owned by
+    /// `Application.Connections.Storage`, so its `deinit` can run from inside `Application.storage`'s
+    /// own locked teardown, and going back through that storage re-enters a non-recursive lock.
+    /// Holding the bus directly also guarantees we unregister from the same instance we subscribed to
+    /// `application.events` mints a fresh ephemeral bus once the app is shutting down.
+    private let eventBus: EventBus
+
+    /// The identity our EventBus subscriptions are filed under. Captured during `init` because
+    /// deriving it in `deinit` would require passing a deallocating `self` as an `AnyObject`.
+    private var eventBusOwner: ObjectIdentifier? = nil
+
     /// The inbound vs outbound buffer
     private var buffer: Int
 
@@ -116,6 +129,7 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         upgradeTimeout: TimeAmount = Application.Connections.defaultUpgradeTimeout
     ) {
         self.application = application
+        self.eventBus = application.events
         self.eventLoop = application.eventLoopGroup.next()
         self.logger = application.logger
         self.logger[metadataKey: "ConnManager"] = .string("[\(UUID().uuidString.prefix(5))]")
@@ -126,17 +140,27 @@ final class BasicInMemoryConnectionManager: ConnectionManager, @unchecked Sendab
         self.buffer = Int(Double(maxPeers) * 0.2)
         self.upgradeTimeout = upgradeTimeout
 
-        /// Subscribe to onDisconnect events
-        self.application.events.on(self, event: .disconnected(onDisconnectedNew))
-        /// Subscribe to onUpgraded events so we can disarm a Connection's upgrade timeout
-        self.application.events.on(self, event: .upgraded(onUpgraded))
+        // Every subscription captures `self` weakly to avoid retain cycles
+        self.eventBus.on(self, event: .disconnected({ [weak self] conn, peer in
+            self?.onDisconnectedNew(conn, peer: peer)
+        }))
+        self.eventBus.on(self, event: .upgraded({ [weak self] conn in self?.onUpgraded(conn) }))
         if ASCEnabled {
             self.application.events.on(self, event: .openedStream(onOpenedStream))
             self.application.events.on(self, event: .closedStream(onClosedStream))
         } else {
-            self.application.events.on(self, event: .openedStream(onOpenedStreamCounter))
+            self.eventBus.on(self, event: .openedStream({ [weak self] s in self?.onOpenedStreamCounter(s) }))
         }
+        self.eventBusOwner = ObjectIdentifier(self)
         self.logger.trace("Initialized \(ASCEnabled ? "with" : "without") Automatic Stream Counting")
+    }
+
+    deinit {
+        // Cancels the bus's drain tasks for our subscriptions. Reachable only because the callbacks
+        // above capture `self` weakly.
+        if let owner = self.eventBusOwner {
+            self.eventBus.unregister(owner: owner)
+        }
     }
 
     func setMaxConnections(_ maxConnections: Int) {

--- a/Sources/LibP2P/EventBus/EventBus.swift
+++ b/Sources/LibP2P/EventBus/EventBus.swift
@@ -285,7 +285,16 @@ public final class EventBus: Sendable {
 
     /// Removes every callback registered under `object`'s identity across all event kinds.
     public func unregister(_ object: AnyObject) {
-        let owner = ObjectIdentifier(object)
+        self.unregister(owner: ObjectIdentifier(object))
+    }
+
+    /// Removes every callback registered under `owner` across all event kinds.
+    ///
+    /// Subscribers that unregister from their own `deinit` must use this overload with an identity
+    /// captured while they were still alive. Passing `self` to ``unregister(_:)`` from `deinit` hands a
+    /// deallocating object to an `AnyObject` parameter, which retains and then re-releases it at a
+    /// refcount of zero — an over-release that crashes the process.
+    public func unregister(owner: ObjectIdentifier) {
         let tokens = self.registry.withLockedValue { registry in
             registry.callbackTokens.removeValue(forKey: owner) ?? []
         }

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -387,7 +387,7 @@ extension LibP2PTests {
         // MARK: - Connectedness, pruning & manager lifetime
 
         /// A connection that has closed but hasn't been pruned yet still sits in the registry. Reporting
-        /// its peer as `.Connected` would claim a live connection to a peer we've already hung up on.
+        /// its peer as `.Connected` would claim a live connection to a peer we've already closed.
         @Test("A closed-but-unpruned connection doesn't report its peer as connected")
         func testClosedConnectionIsNotConnectedness() async throws {
             try await withApp { app in

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -218,5 +218,83 @@ extension LibP2PTests {
                 #expect(try await manager.getConnections(on: loop).get().count == 1)
             }
         }
+
+        // MARK: - Upgrade timeout
+
+        /// Connections are registered the moment their channel becomes active
+        /// A peer that connects and then goes silent must be closed and cleaned up
+        @Test("Connection manager closes connections that never finish upgrading")
+        func testConnectionManagerReapsStalledUpgrades() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(
+                    application: app,
+                    maxPeers: 10,
+                    ASCEnabled: false,
+                    upgradeTimeout: .milliseconds(100)
+                )
+                let loop = app.eventLoopGroup.next()
+                let channel = NIOAsyncTestingChannel()
+                let connection = BasicConnectionLight(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil
+                )
+
+                try await manager.addConnection(connection, on: loop).get()
+                #expect(try await manager.getConnections(on: loop).get().count == 1)
+                // The connection never gets secured or muxed, so it stays short of `.upgraded`.
+                #expect(connection.status != .upgraded)
+
+                // Wait out the upgrade window (plus slack for the scheduled task to run).
+                try await Task.sleep(for: .milliseconds(500))
+
+                #expect(try await manager.getConnections(on: loop).get().isEmpty)
+
+                // The close itself was dispatched onto the connection's own testing
+                // loop, so run it to confirm the manager actually tore the connection down.
+                await channel.testingEventLoop.run()
+                #expect(connection.status == .closed)
+            }
+        }
+
+        /// A connection that completes its upgrade inside the window must keep its slot
+        /// the manager disarms the deadline when it observes the `.upgraded` event.
+        @Test("Upgrading within the window disarms the upgrade timeout")
+        func testUpgradeDisarmsTheUpgradeTimeout() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(
+                    application: app,
+                    maxPeers: 10,
+                    ASCEnabled: false,
+                    upgradeTimeout: .milliseconds(100)
+                )
+                let loop = app.eventLoopGroup.next()
+                let channel = NIOAsyncTestingChannel()
+                let connection = BasicConnectionLight(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil
+                )
+
+                try await manager.addConnection(connection, on: loop).get()
+
+                // Hand the manager the same notification the connection posts once it's secured & muxed.
+                // The event itself should be enough to cancel the timeout (even though the connection's
+                // status isn't really `.upgraded`).
+                manager.onUpgraded(connection)
+
+                try await Task.sleep(for: .milliseconds(500))
+
+                #expect(try await manager.getConnections(on: loop).get().count == 1)
+
+                // Nothing was scheduled against the connection, so draining its loop leaves it untouched.
+                await channel.testingEventLoop.run()
+                #expect(connection.status != .closed)
+            }
+        }
     }
 }

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -296,5 +296,92 @@ extension LibP2PTests {
                 #expect(connection.status != .closed)
             }
         }
+
+        // MARK: - Shutdown & bookkeeping
+
+        /// Teardown must drain every connection, including ones that never finished their security
+        /// handshake and therefore have no `remotePeer`.
+        @Test("closeAllConnections clears every connection, even peer-less ones")
+        func testCloseAllConnectionsClearsPeerlessConnections() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: false)
+                let loop = app.eventLoopGroup.next()
+
+                // `DummyConnection` has no `remotePeer` — exactly the case that used to abort teardown.
+                let connection = DummyConnection(direction: .inbound)
+                #expect(connection.remotePeer == nil)
+
+                try await manager.addConnection(connection, on: loop).get()
+                #expect(try await manager.getConnections(on: loop).get().count == 1)
+
+                // `DummyConnection.close()` fails by design, so the drain future fails — the teardown
+                // bookkeeping still has to run to completion.
+                _ = try? await manager.closeAllConnections().get()
+
+                #expect(try await manager.getConnections(on: loop).get().isEmpty)
+                #expect(try await manager.perConnectionBookkeepingCount().get() == 0)
+            }
+        }
+
+        @Test("closeAllConnections is idempotent")
+        func testCloseAllConnectionsIsIdempotent() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: false)
+
+                try await manager.closeAllConnections().get()
+                try await manager.closeAllConnections().get()
+            }
+        }
+
+        /// Once the manager is shutting down it must reject new connections with a .shuttingDown error
+        @Test("addConnection is rejected with .shuttingDown once the manager is closed")
+        func testAddConnectionRejectedAfterShutdown() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: false)
+                let loop = app.eventLoopGroup.next()
+
+                try await manager.closeAllConnections().get()
+
+                await #expect(throws: BasicInMemoryConnectionManager.Errors.shuttingDown) {
+                    try await manager.addConnection(DummyConnection(direction: .outbound), on: loop).get()
+                }
+            }
+        }
+
+        /// Unregistering a connection must drop all of its per-connection bookkeeping. The idle-close
+        /// task and the ARC slow-loop alert entry used to be cleared only on the paths that scheduled
+        /// them, so a connection torn down any other way leaked both entries permanently.
+        @Test("Unregistering a connection leaves no per-connection bookkeeping behind")
+        func testUnregisteringConnectionClearsBookkeeping() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(
+                    application: app,
+                    maxPeers: 10,
+                    ASCEnabled: false,
+                    upgradeTimeout: .milliseconds(100)
+                )
+                let loop = app.eventLoopGroup.next()
+                let channel = NIOAsyncTestingChannel()
+                let connection = BasicConnectionLight(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil
+                )
+
+                try await manager.addConnection(connection, on: loop).get()
+                // The armed upgrade timeout is the only bookkeeping we expect at this point.
+                #expect(try await manager.perConnectionBookkeepingCount().get() == 1)
+
+                // Let the upgrade window elapse so the manager closes and unregisters the connection.
+                try await Task.sleep(for: .milliseconds(500))
+
+                #expect(try await manager.getConnections(on: loop).get().isEmpty)
+                #expect(try await manager.perConnectionBookkeepingCount().get() == 0)
+
+                await channel.testingEventLoop.run()
+            }
+        }
     }
 }

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -383,5 +383,70 @@ extension LibP2PTests {
                 await channel.testingEventLoop.run()
             }
         }
+
+        // MARK: - Connectedness, pruning & manager lifetime
+
+        /// A connection that has closed but hasn't been pruned yet still sits in the registry. Reporting
+        /// its peer as `.Connected` would claim a live connection to a peer we've already hung up on.
+        @Test("A closed-but-unpruned connection doesn't report its peer as connected")
+        func testClosedConnectionIsNotConnectedness() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: false)
+                let loop = app.eventLoopGroup.next()
+                let remotePeer = try PeerID(.Ed25519)
+
+                // `DummyConnection` is born `.closed`, which is exactly the state we care about here.
+                let connection = DummyConnection(direction: .inbound)
+                connection.remotePeer = remotePeer
+                #expect(connection.status == .closed)
+
+                try await manager.addConnection(connection, on: loop).get()
+                // Still registered — this is the unpruned window.
+                #expect(try await manager.getConnections(on: loop).get().count == 1)
+
+                let connectedness = try await manager.connectedness(peer: remotePeer, on: loop).get()
+                #expect(connectedness != .Connected)
+            }
+        }
+
+        /// `debouncedPrune()` used to hand back the scheduled task's future, which fired the moment the
+        /// debounce timer triggered, before the prune actaully ran. Awaiting it must now mean the pruning is done.
+        @Test("The prune future resolves only after pruning has actually run")
+        func testPruneFutureAwaitsTheActualPrune() async throws {
+            try await withApp { app in
+                let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: false)
+                let loop = app.eventLoopGroup.next()
+
+                // A `.closed` connection is what `pruneClosedConnections` clears.
+                let connection = DummyConnection(direction: .inbound)
+                try await manager.addConnection(connection, on: loop).get()
+                #expect(try await manager.getConnections(on: loop).get().count == 1)
+
+                try await manager.debouncedPrune().get()
+
+                // No sleep, no polling: if the future is honest, the prune has already happened.
+                #expect(try await manager.getConnections(on: loop).get().isEmpty)
+            }
+        }
+
+        /// The EventBus retains every callback in a drain task for its own lifetime, so subscribing with
+        /// bound method references pinned the manager forever and its `deinit` could never run. The
+        /// manager must be free to deallocate once nothing else holds it.
+        @Test("A released connection manager deallocates instead of leaking into the EventBus")
+        func testManagerDeallocatesAfterRelease() async throws {
+            try await withApp { app in
+                weak var weakManager: BasicInMemoryConnectionManager?
+
+                do {
+                    let manager = BasicInMemoryConnectionManager(application: app, maxPeers: 10, ASCEnabled: true)
+                    weakManager = manager
+                    #expect(weakManager != nil)
+                    // Touch it so the compiler can't shorten its lifetime past this point.
+                    _ = try await manager.getConnections(on: app.eventLoopGroup.next()).get()
+                }
+
+                #expect(weakManager == nil)
+            }
+        }
     }
 }


### PR DESCRIPTION
### What?
This PR cleans up the BasicInMemoryConnectionManager

### Changes
- Ensure all state handling is done on our event loop
- Better connection pruning logic (along with a promise that completes when the prune is done)
- Connection upgrade timeouts (guards against a Connection stalling while trying to negotiate a sec or muxer)
- Safer EventBus subscriptions (got rid of a retain cycle)
- Added tests