### PR TITLE
BaseConnection

### DIFF
--- a/Sources/LibP2P/Connections/BaseConnection.swift
+++ b/Sources/LibP2P/Connections/BaseConnection.swift
@@ -1,0 +1,1331 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LibP2PCore
+import Logging
+
+/// BaseConnection
+///
+/// Handles upgrading the Connection (installing the negotiated security and muxer) and once
+/// upgraded, handles the creation and lifecycle of multiplexed streams.
+///
+/// BaseConnection leverages the new StreamGater and StreamPruner protocols to offload
+/// the management of Streams into plugable/configurable async actors.
+///
+/// To install / register a StreamGater or StreamPruner, use the app...
+///  ```
+///  app.connectionManager.use(streamGater: )
+///  app.connectionManager.use(streamPruner: )
+///  ```
+public final class BaseConnection: AppConnection, @unchecked Sendable {
+
+    public let application: Application
+
+    public let channel: Channel
+    private var eventLoop: EventLoop {
+        self.channel.eventLoop
+    }
+
+    public let id: UUID
+
+    public var localAddr: Multiaddr?
+
+    public var remoteAddr: Multiaddr?
+
+    public let localPeer: PeerID
+
+    public var remotePeer: PeerID?
+
+    public var expectedRemotePeer: PeerID?
+
+    public let stats: ConnectionStats
+
+    public var tags: Any? = nil
+
+    public private(set) var registry: [UInt64: LibP2PCore.Stream] = [:]
+
+    public var streams: [LibP2PCore.Stream] {
+        self.muxer?.streams ?? []
+    }
+
+    public weak var muxer: Muxer? = nil
+
+    public var isMuxed: Bool = false
+
+    public var status: ConnectionStats.Status {
+        self.stats.status
+    }
+
+    public var timeline: [ConnectionStats.Status: Date] {
+        self.stats.timeline.history
+    }
+
+    /// Our Connection's Logger
+    public var logger: Logger
+
+    /// Decides which streams we're willing to carry.
+    private let streamGater: StreamGater
+
+    /// Decides which of our streams get evicted.
+    private let streamPruner: StreamPruner
+
+    struct StreamStateEntry {
+        let proto: String
+        let direction: ConnectionStats.Direction
+        let state: StreamState
+        let date: Date
+    }
+    /// Keep track of our Streams and thier lifecycle history.
+    /// Feeds `lastActivity()`, which our ConnectionManager reads.
+    internal private(set) var streamHistory: [StreamStateEntry] = []
+
+    private var stateMachine: ConnectionStateMachine
+    public var state: ConnectionState {
+        self.stateMachine.state
+    }
+
+    /// These promises are used only once while upgrading the parent channel
+    private let securedPromise: EventLoopPromise<SecuredResult>
+    private let muxedPromise: EventLoopPromise<Muxer>
+
+    /// The timestamp at which this connection was instantiated
+    private let startTime: UInt64
+
+    // MARK: - Idle connection teardown
+
+    /// The IdleTimeout Task that gets set each time our connection gets to zero (0) open streams.
+    /// We wait `idleTimeoutMilliseconds` for a new Stream to be opened. If one isn't opened in that
+    /// window, the connection shuts down and deinits itself.
+    ///
+    /// - TODO: This belongs in the `ConnectionManager`
+    private var idleTimeoutTask: Scheduled<Void>? = nil
+    /// The time in milliseconds that our connection will sit idle before terminating itself.
+    private var idleTimeoutMilliseconds: Int64 = 250
+
+    // MARK: - Stream pruning
+
+    /// What we track per muxed stream so `streamPruner` can reason about liveness.
+    ///
+    /// Keyed by `ObjectIdentifier(childChannel)` rather than by stream `id`, because some muxer
+    /// stream IDs are only unique per direction (mplex)
+    private struct StreamRecord {
+        let channel: Channel
+        let direction: ConnectionStats.Direction
+        let openedAt: Date
+        let activity: StreamActivityRecord
+        /// The pre-negotiation gater verdict: succeeds on accept, fails on reject.
+        let inboundGate: EventLoopFuture<Void>
+        /// Resolved once the stream has negotiated a protocol; `nil` while it's still upgrading.
+        var stream: LibP2PCore.Stream?
+        var negotiatedAt: Date?
+    }
+    private var streamRecords: [ObjectIdentifier: StreamRecord] = [:]
+
+    /// The repeating sweep that asks our `streamPruner` what to evict.
+    /// Started once we're muxed and cancelled on teardown.
+    private var pruneSweepTask: RepeatedTask? = nil
+
+    public convenience init(
+        application: Application,
+        channel: Channel,
+        direction: ConnectionStats.Direction,
+        remoteAddress: Multiaddr,
+        expectedRemotePeer: PeerID?
+    ) {
+        self.init(
+            application: application,
+            channel: channel,
+            direction: direction,
+            remoteAddress: remoteAddress,
+            expectedRemotePeer: expectedRemotePeer,
+            streamGater: application.connectionManager.streamGater,
+            streamPruner: application.connectionManager.streamPruner
+        )
+    }
+
+    /// Designated initializer, taking the gater and pruner explicitly.
+    ///
+    /// - Note: Designed to be used in Tests so we can explicitly install Gaters and Pruners
+    internal init(
+        application: Application,
+        channel: Channel,
+        direction: ConnectionStats.Direction,
+        remoteAddress: Multiaddr,
+        expectedRemotePeer: PeerID?,
+        streamGater: StreamGater,
+        streamPruner: StreamPruner
+    ) {
+        let id = UUID()
+        self.id = id
+        self.application = application
+        self.logger = Logger(
+            label: "BaseConnection[\(application.peerID.shortDescription)][\(id.uuidString.prefix(5))]"
+        )
+        self.logger.logLevel = application.logger.logLevel
+        self.channel = channel
+        self.stateMachine = ConnectionStateMachine()
+        self.streamGater = streamGater
+        self.streamPruner = streamPruner
+
+        // Addresses
+        self.localAddr = try? channel.localAddress?.toMultiaddr()
+        self.remoteAddr = remoteAddress
+
+        // Peers
+        self.localPeer = application.peerID
+        self.remotePeer = nil
+        self.expectedRemotePeer = expectedRemotePeer
+
+        /// Metadata
+        self.registry = [:]
+        self.tags = nil
+        self.stats = ConnectionStats(uuid: id, direction: direction)
+
+        /// State Promises
+        self.securedPromise = channel.eventLoop.makePromise(of: SecuredResult.self)
+        self.muxedPromise = channel.eventLoop.makePromise(of: Muxer.self)
+
+        self.startTime = DispatchTime.now().uptimeNanoseconds
+
+        /// Register our channel's close future
+        self.channel.closeFuture.whenComplete { [weak self] _ in
+            guard let self = self else { return }
+            self.logger.trace("Channel -> CloseFuture")
+            self.stats.status = .closed
+
+            /// Teardown any tasks we've started
+            self.cancelPruneSweep()
+            self.cancelTimeoutTask()
+
+            /// Fail any streams that were queued while we were still upgrading. If the channel closed
+            /// before we finished muxing, those streams will never open. Surface the failure to their
+            /// callers immediately (this is what fails coalesced cold dials when an upgrade fails)
+            /// rather than leaving each request to hit its own timeout.
+            self.failQueuedStreams(Application.Connections.Errors.connectionUpgradeFailed)
+
+            /// Should ensure that we actually connected before posting a disconnect event
+            if self.application.isRunning {
+                self.application.events.post(.disconnected(self, self.remotePeer))
+            }
+
+            self.muxer?.onStream = nil
+            self.muxer?.onStreamEnd = nil
+            self.muxer?._connection = nil
+            self.muxer = nil
+            self.registry = [:]
+            self.streamRecords = [:]
+        }
+
+        self.logger.trace("Initialized")
+    }
+
+    deinit {
+        /// We had a leaking promise get triggered here... When our connection deinitializes before the
+        /// securedPromise / muxedPromise are completed...
+        switch self.state {
+        case .raw:
+            self.securedPromise.fail(Application.Connections.Errors.timedOut)
+            self.muxedPromise.fail(Application.Connections.Errors.timedOut)
+        case .secured:
+            self.muxedPromise.fail(Application.Connections.Errors.timedOut)
+        default:
+            break
+        }
+        self.cancelTimeoutTask()
+        self.cancelPruneSweep()
+        self.logger.trace("Deinitialized")
+    }
+
+    /// This method is called immediately after a new Connection is instantiated with a channel.
+    /// It's sole priority is to register our sec and muxer callbacks and kick off the security upgrade.
+    public func initializeChannel() -> EventLoopFuture<Void> {
+        /// Add our future result handlers to our Connection's state change promises
+        self.securedPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self else { return }
+            self.onSecured(result)
+        }
+
+        self.muxedPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self else { return }
+            self.onMuxed(result)
+        }
+
+        self.stats.status = .opening
+
+        /// Kickoff security upgrade (also responsible for negotiation)
+        return self.secureConnection(promise: self.securedPromise).always { [weak self] _ in
+            guard let self = self else { return }
+            self.stats.status = .open
+        }
+    }
+
+    // MARK: - Upgrade
+
+    private func onSecured(_ result: Result<SecuredResult, Error>) {
+        switch result {
+        case .failure(let error):
+            self.logger.error("Failed to secure channel: \(error)")
+            self.channel.close(mode: .all, promise: nil)
+            return
+        case .success(let security):
+            do {
+                self.logger.info(
+                    "Secured with `\(security.securityCodec)`! RemotePeer: \(String(describing: security.remotePeer)), Warnings: \(String(describing: security.warning))"
+                )
+                self.remotePeer = security.remotePeer
+                self.logger.info("Remote Address: \(self.remoteAddr?.description ?? "NIL")")
+                try self.stateMachine.secureConnection()
+                self.stats.encryption = security.securityCodec
+
+                if let rPeer = self.remotePeer {
+                    let pInfo = PeerInfo(peer: rPeer, addresses: [])
+                    self.application.events.post(.remotePeer(pInfo))
+                } else {
+                    self.logger.warning("Post Security handshake without knowledge of RemotePeer and/or RemoteAddress")
+                }
+
+                /// Kick off Muxer upgrade
+                self.muxConnection(promise: self.muxedPromise).whenComplete { res in
+                    switch res {
+                    case .failure(let error):
+                        self.logger.error("Failed to negotiate muxer: \(error)")
+                        self.channel.close(mode: .all, promise: nil)
+                        return
+                    case .success:
+                        self.logger.trace("Attempting to negotiate and install Muxer")
+                    }
+                }
+            } catch {
+                self.logger.error("Failed to secure channel: \(error)")
+                self.channel.close(mode: .all, promise: nil)
+                return
+            }
+        }
+    }
+
+    private func onMuxed(_ result: Result<Muxer, Error>) {
+        switch result {
+        case .failure(let error):
+            self.logger.error("Failed to mux channel: \(error)")
+            self.channel.close(mode: .all, promise: nil)
+            return
+        case .success(let muxer):
+            do {
+                self.logger.info("Muxed with \(muxer)")
+                self.muxer = muxer
+                self.isMuxed = true
+                try self.stateMachine.muxConnection()
+                self.stats.status = .upgraded
+                self.stats.muxer = muxer.protocolCodec
+
+                /// Callbacks driving idle connection teardown
+                self.muxer?.onStream = self.onNewStream
+                self.muxer?.onStreamEnd = self.onStreamClosed
+
+                let timeToUpgrade = DispatchTime.now().uptimeNanoseconds - self.startTime
+                self.logger.notice("Upgrade Time: \(timeToUpgrade / 1_000_000) ms")
+
+                self.eventLoop.execute {
+                    /// Our connection is upgraded...
+                    self.logger.trace("Our connection has been Secured and Muxed! We're ready to rock!")
+                    self.application.events.post(.connected(self))
+                    self.application.events.post(.upgraded(self))
+
+                    /// Now that streams are possible, start sweeping for dead ones.
+                    self.armPruneSweep()
+
+                    /// Open any pending streams now that we're muxed
+                    ///
+                    /// TODO: Not sure about this error handling....
+                    for pendingStream in self.pendingStreamCache {
+                        self.logger.debug(
+                            "Asking Muxer to open / initialize pending stream for protocol `\(pendingStream.proto)`"
+                        )
+                        self.newStreamCache.append(pendingStream)
+                        do {
+                            try muxer.newStream(channel: self.channel, proto: pendingStream.proto).whenComplete {
+                                result in
+                                switch result {
+                                case .success:
+                                    break
+                                case .failure(let error):
+                                    self.fail(pendingStream, with: error)
+                                }
+                            }
+                        } catch {
+                            self.fail(pendingStream, with: error)
+                        }
+                    }
+                    self.pendingStreamCache = []
+                }
+
+            } catch {
+                self.logger.error("Failed to mux channel: \(error)")
+                self.channel.close(mode: .all, promise: nil)
+                return
+            }
+        }
+    }
+
+    // MARK: - Idle connection teardown
+
+    /// Called by our Muxer when a stream of ours has been closed.
+    /// - Note: We take this opportunity to check if there are any active streams and kick off our
+    ///   idleTimeoutTask if there aren't.
+    private func onStreamClosed(_ stream: LibP2PCore.Stream) {
+        self.logger.trace("On Stream Closed...")
+        guard let mux = self.muxer else {
+            self.logger.trace("No Muxer Available")
+            return
+        }
+        if mux.streams.isEmpty {
+            self.logger.trace("No Streams")
+            if self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty {
+                self.logger.trace("No Pending Streams")
+                self.armTimeoutTask()
+            }
+        } else {
+            self.logger.trace("We still have \(mux.streams.count) streams")
+            self.logger.trace(
+                "\(mux.streams.map { "Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)][\($0.streamState)]" }.joined(separator: "\n") )"
+            )
+        }
+    }
+
+    /// Called by our Muxer when a new stream has been opened
+    /// - Note: We take this opportunity to cancel the idleTimeoutTask if one exists.
+    private func onNewStream(_ stream: LibP2PCore.Stream) {
+        self.eventLoop.execute {
+            self.cancelTimeoutTask()
+            self.logger.trace("Notified of new stream, canceling existing idleTimeoutTask")
+        }
+    }
+
+    private func cancelTimeoutTask() {
+        self.idleTimeoutTask?.cancel()
+        self.idleTimeoutTask = nil
+    }
+
+    private func armTimeoutTask() {
+        guard self.idleTimeoutTask == nil else { return }
+        self.idleTimeoutTask = self.eventLoop.scheduleTask(in: .milliseconds(self.idleTimeoutMilliseconds)) {
+            /// Close ourselves and notify our connection manager
+            guard self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty else {
+                self.idleTimeoutTask = nil
+                return
+            }
+            self.logger.debug("Idle timeout reached. Terminating self")
+            let _ = self.close()
+        }
+    }
+
+    // MARK: - Stream gating
+
+    /// Bridges the (actor-isolated) gater's verdict back onto `childChannel`'s event loop.
+    ///
+    /// The returned future succeeds on `.accept` and fails on `.reject`, so callers can simply chain
+    /// their pipeline configuration off it.
+    private func gate(
+        _ decide: @escaping @Sendable () async -> StreamGateDecision,
+        on childChannel: Channel,
+        describing what: String
+    ) -> EventLoopFuture<Void> {
+        let promise = childChannel.eventLoop.makePromise(of: Void.self)
+        let logger = self.logger
+        let eventLoop = childChannel.eventLoop
+        Task {
+            let decision = await decide()
+            eventLoop.execute {
+                switch decision {
+                case .accept:
+                    promise.succeed(())
+                case .reject(let reason):
+                    logger.notice("StreamGater rejected \(what): \(reason)")
+                    promise.fail(Errors.streamRejectedByGater(reason: reason))
+                }
+            }
+        }
+        return promise.futureResult
+    }
+
+    /// Asks the gater about a stream whose protocol has just been agreed.
+    private func gateNegotiatedStream(
+        protocol proto: String,
+        direction: ConnectionStats.Direction,
+        on childChannel: Channel
+    ) -> EventLoopFuture<Void> {
+        let context = NegotiatedStreamGateContext(
+            connectionID: self.id,
+            remotePeer: self.remotePeer,
+            remoteAddress: self.remoteAddr,
+            direction: direction,
+            protocolCodec: proto,
+            openStreamCount: self.muxer?.streams.count ?? 0
+        )
+        let gater = self.streamGater
+        return self.gate(
+            { await gater.shouldAcceptNegotiatedStream(context) },
+            on: childChannel,
+            describing: "\(direction) `\(proto)` stream"
+        )
+    }
+
+    // MARK: - Child channels
+
+    /// This function gets called by our Muxer when instantiating a new inbound child Channel.
+    /// Take this opportunity to configure the child channel's pipeline before data transmission begins.
+    ///
+    /// - Important: The future we return is what gates the child channel's *activation*, and it must
+    ///   complete within this event-loop tick. Muxers differ sharply here: `mplex` buffers inbound
+    ///   frames in `pendingReads` until activation, but YAMUX's child-channel state machine treats any
+    ///   frame arriving while the stream is still `.requestedRemotely` as a protocol violation
+    ///   (`YAMUX.Error.protocolViolation`) — it only sends the open-confirmation once this future
+    ///   resolves. A peer that pipelines its payload behind the stream-open therefore breaks the stream
+    ///   if we suspend here. So the multistream-select upgrader is installed *synchronously* and the
+    ///   gater is consulted concurrently; see ``StreamGater/shouldAcceptInboundStream(_:)`` for what
+    ///   that means for the guarantee.
+    public func inboundMuxedChildChannelInitializer(_ childChannel: Channel) -> EventLoopFuture<Void> {
+        // Cancel our idleTimeoutTask if we have one
+        self.cancelTimeoutTask()
+
+        let context = InboundStreamGateContext(
+            connectionID: self.id,
+            remotePeer: self.remotePeer,
+            remoteAddress: self.remoteAddr,
+            openStreamCount: self.muxer?.streams.count ?? 0
+        )
+        let gater = self.streamGater
+        let gate = self.gate(
+            { await gater.shouldAcceptInboundStream(context) },
+            on: childChannel,
+            describing: "inbound stream"
+        )
+
+        // Start tracking the stream for pruning purposes right away — a stream that never negotiates
+        // is exactly the sort of thing the pruner exists to reap. The gate future rides along so the
+        // negotiation path can re-check it before installing any route handlers.
+        self.trackStream(on: childChannel, direction: .inbound, inboundGate: gate)
+
+        // Tear a rejected stream down as soon as the gater answers, rather than waiting for it to
+        // negotiate a protocol it will never be allowed to use.
+        gate.whenFailure { [weak self] _ in
+            guard let self = self else { return }
+            self.untrackStream(on: childChannel)
+            self.muxer?.removeStream(channel: childChannel)
+        }
+
+        return self.configureInboundUpgrader(on: childChannel)
+    }
+
+    /// Installs the multistream-select listener on an accepted inbound child channel.
+    private func configureInboundUpgrader(on childChannel: Channel) -> EventLoopFuture<Void> {
+        let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+
+        let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
+            protocols: self.application.routes.all.map { $0.description },
+            mode: .listener,
+            logger: self.logger,
+            promise: negotiationPromise
+        )
+
+        negotiationPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self, self.application.isRunning else { return }
+            switch result {
+            case .failure(let error):
+                self.untrackStream(on: childChannel)
+                self.muxer?.removeStream(channel: childChannel)
+                self.logger.error("Error while upgrading Inbound ChildChannel: \(error)")
+
+            case .success(let proto):
+                /// Append a stream event in our stream history array
+                self.streamHistory.append(
+                    StreamStateEntry(
+                        proto: proto.protocol.description,
+                        direction: .inbound,
+                        state: .initialized,
+                        date: Date()
+                    )
+                )
+
+                /// Re-check the pre-negotiation verdict before doing anything else. It was consulted
+                /// concurrently with installing the upgrader (see the note on
+                /// ``inboundMuxedChildChannelInitializer(_:)``), so a slow gater may not have answered
+                /// yet — but by now the mss upgrader is buffering inbound bytes and nothing has reached a
+                /// route handler, so waiting here is safe and no stream slips past a rejection.
+                self.inboundGate(for: childChannel)
+                    .flatMap {
+                        self.gateNegotiatedStream(protocol: proto.protocol, direction: .inbound, on: childChannel)
+                    }
+                    .whenComplete { gateResult in
+                        switch gateResult {
+                        case .failure:
+                            self.untrackStream(on: childChannel)
+                            self.muxer?.removeStream(channel: childChannel)
+                        case .success:
+                            self.finishUpgrading(
+                                proto,
+                                childChannel: childChannel,
+                                responder: self.application.responder.current,
+                                direction: .inbound
+                            )
+                        }
+                    }
+            }
+        }
+        return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+    }
+
+    /// This function gets called by our Muxer when instantiating a new outbound child Channel.
+    /// Take this opportunity to configure the child channel's pipeline for the specified protocol
+    /// before data transmission begins.
+    public func outboundMuxedChildChannelInitializer(_ childChannel: Channel, protocol: String) -> EventLoopFuture<Void>
+    {
+        self.eventLoop.flatSubmit {
+            // Cancel our idleTimeoutTask if we have one
+            self.cancelTimeoutTask()
+
+            guard let idx = self.newStreamCache.firstIndex(where: { $0.proto == `protocol` }) else {
+                self.logger.error("No Responder For `\(`protocol`)`")
+                self.logger.error("\(self.newStreamCache)")
+                return childChannel.eventLoop.makeFailedFuture(Application.Connections.Errors.noResponder)
+            }
+            let pendingStream = self.newStreamCache.remove(at: idx)
+
+            /// We initiated this stream, so there's no pre-negotiation gate to run — only the
+            /// post-negotiation one below.
+            self.trackStream(on: childChannel, direction: .outbound)
+
+            let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+            let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
+                protocols: [`protocol`],
+                mode: .initiator,
+                logger: self.logger,
+                promise: negotiationPromise
+            )
+
+            negotiationPromise.futureResult.whenComplete { [weak self] result in
+                guard let self = self, self.application.isRunning else { return }
+                switch result {
+                case .failure(let error):
+                    self.untrackStream(on: childChannel)
+                    self.muxer?.removeStream(channel: childChannel)
+                    self.logger.error("Error while upgrading Outbound ChildChannel: \(error)")
+
+                case .success(let proto):
+                    /// Append a stream event in our stream history array
+                    self.streamHistory.append(
+                        StreamStateEntry(
+                            proto: proto.protocol.description,
+                            direction: .outbound,
+                            state: .initialized,
+                            date: Date()
+                        )
+                    )
+
+                    self.gateNegotiatedStream(protocol: proto.protocol, direction: .outbound, on: childChannel)
+                        .whenComplete { gateResult in
+                            switch gateResult {
+                            case .failure(let error):
+                                self.untrackStream(on: childChannel)
+                                self.muxer?.removeStream(channel: childChannel)
+                                /// Our own caller is waiting on this stream — tell them why it died.
+                                self.fail(pendingStream, with: error)
+                            case .success:
+                                self.finishUpgrading(
+                                    proto,
+                                    childChannel: childChannel,
+                                    responder: pendingStream.responder,
+                                    direction: .outbound
+                                )
+                            }
+                        }
+                }
+            }
+            return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+        }
+    }
+
+    /// Shared tail of the inbound and outbound upgrade paths: install the route's handlers, record the
+    /// stream, and announce it.
+    ///
+    /// - Important: Unlike in `ARCConnection`, this does **not** run in the same event-loop tick as
+    ///   protocol negotiation — the ``StreamGater`` consultation in between hops through an actor. The
+    ///   stream can therefore be gone by the time we get here: a route answering `.respondThenClose`
+    ///   over an in-process muxer closes it within that window essentially every time. Configuring a
+    ///   dead stream's pipeline is meaningless everywhere, and outright fatal on muxers whose stream
+    ///   channel releases its `ChannelPipeline` on close, so bail out first.
+    private func finishUpgrading(
+        _ proto: NegotiationResult,
+        childChannel: Channel,
+        responder: Responder,
+        direction: ConnectionStats.Direction
+    ) {
+        guard childChannel.isActive else {
+            self.logger.debug(
+                "`\(proto.protocol)` stream closed while it was being gated; skipping pipeline configuration"
+            )
+            self.untrackStream(on: childChannel)
+            return
+        }
+
+        self.upgradeChildChannel(
+            proto,
+            childChannel: childChannel,
+            responder: responder,
+            direction: direction
+        ).whenComplete { [weak self] result in
+            guard let self = self, self.application.isRunning else { return }
+
+            /// Append a stream event in our stream history array
+            self.streamHistory.append(
+                StreamStateEntry(proto: proto.protocol, direction: direction, state: .open, date: Date())
+            )
+
+            self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
+            self.logger.debug("🔀 New \(direction) ChildChannel[`\(proto)`] Ready!")
+            self.logger.trace("List of Streams:")
+            self.logger.trace(
+                "\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))"
+            )
+
+            // Post about the new stream on our application's Event Bus
+            guard case .success = result else { return }
+            guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
+            str._connection.withLockedValue { $0 = self }
+            /// Now that the muxer has a fully formed Stream for this channel, hand it to the pruner's
+            /// bookkeeping so eviction can go through the Stream API rather than the raw channel.
+            self.resolveTrackedStream(str, on: childChannel)
+            self.application.events.post(.openedStream(str))
+            childChannel.closeFuture.whenComplete { [weak self] _ in
+                guard let self = self else { return }
+                /// Append a stream event in our stream history array
+                self.streamHistory.append(
+                    StreamStateEntry(proto: proto.protocol, direction: direction, state: .closed, date: Date())
+                )
+                self.application.events.post(.closedStream(str))
+            }
+        }
+    }
+
+    /// To be called when the childChannel's protocol negotiation completes
+    ///
+    /// Note: Also is responsible for forwarding any leftover bytes received during the childChannel
+    /// upgrade process
+    private func upgradeChildChannel(
+        _ proto: NegotiationResult,
+        childChannel: Channel,
+        responder: Responder,
+        direction: ConnectionStats.Direction
+    ) -> EventLoopFuture<Void> {
+        //Install the protocol on the channel's pipeline...
+        logger.trace("Negotiated \(proto)")
+
+        /// `muxer` is held weakly, and the gate hop before us means the connection may have torn down
+        /// since negotiation completed.
+        guard let muxer = self.muxer else {
+            logger.debug("Muxer went away before `\(proto.protocol)` could be installed")
+            return childChannel.eventLoop.makeFailedFuture(
+                Application.Connections.Errors.connectionUpgradeFailed
+            )
+        }
+        guard var handlers = responder.pipelineConfig(for: proto.protocol, on: self) else {
+            /// Unhandled protocol negotiated
+            logger.trace("Unhandled protocol negotiated `\(proto.protocol)`")
+            return childChannel.eventLoop.makeSucceededVoidFuture()
+        }
+        logger.trace("Attempting to install route (`\(proto)`) specific ChannelHandlers")
+        logger.trace("\(handlers.map({ String(describing: $0) }).joined(separator: ", "))")
+
+        /// Prepare our activity monitor for the Encoder / Decoder handlers
+        let activity = self.activityRecord(for: childChannel)
+
+        handlers.append(
+            contentsOf: [
+                RequestEncoderChannelHandler(
+                    application: application,
+                    connection: self,
+                    protocol: proto.protocol,
+                    logger: logger,
+                    direction: direction,
+                    activity: activity
+                ),
+                ResponseDecoderChannelHandler(logger: logger, activity: activity),
+                ResponderChannelHandler(responder: responder, logger: logger),
+            ] as [ChannelHandler]
+        )
+
+        let codec = proto.protocol
+
+        /// Every step below is separated from the next by at least one event-loop tick (`updateStream`
+        /// hops through the muxer's loop; each `flatMap` can span ticks), so the stream may close
+        /// on us mid-operation.
+        ///
+        /// Configuring a dead stream's pipeline is meaningless, so each step checks first. And a porely
+        /// implemented muxer that destroys it's pipeline on close / teardown, could cause us to trap here,
+        /// so we check before proceeding
+        return muxer.updateStream(channel: childChannel, state: .open, proto: codec).flatMap {
+            () -> EventLoopFuture<Void> in
+            guard self.streamIsStillOpen(childChannel, proto: codec) else {
+                return childChannel.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
+            }
+            return childChannel.pipeline.addHandlers(handlers, position: .last)
+        }.flatMap { () -> EventLoopFuture<Void> in
+            guard self.streamIsStillOpen(childChannel, proto: codec) else {
+                return childChannel.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
+            }
+            return childChannel.pipeline.removeHandler(name: "upgrader")
+        }.flatMap { () -> EventLoopFuture<Void> in
+            guard let lo = proto.leftoverBytes, lo.readableBytes > 0 else {
+                return childChannel.eventLoop.makeSucceededVoidFuture()
+            }
+            guard self.streamIsStillOpen(childChannel, proto: codec), childChannel.isWritable else {
+                self.logger.error("Failed to forward leftover bytes along pipeline")
+                return childChannel.eventLoop.makeSucceededVoidFuture()
+            }
+            self.logger.trace("Forwarding leftover bytes along pipeline...")
+            childChannel.pipeline.fireChannelRead(NIOAny(proto.leftoverBytes))
+            return childChannel.eventLoop.makeSucceededVoidFuture()
+        }
+    }
+
+    /// Whether it's still worth touching `childChannel.pipeline`.
+    private func streamIsStillOpen(_ childChannel: Channel, proto: String) -> Bool {
+        guard childChannel.isActive else {
+            self.logger.debug("`\(proto)` stream closed mid-upgrade; abandoning its pipeline")
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Stream pruning
+
+    /// Begin tracking a child channel. Called the moment we learn of a stream, negotiated or not.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func trackStream(
+        on childChannel: Channel,
+        direction: ConnectionStats.Direction,
+        inboundGate: EventLoopFuture<Void>? = nil
+    ) {
+        let key = ObjectIdentifier(childChannel)
+        guard self.streamRecords[key] == nil else { return }
+        self.streamRecords[key] = StreamRecord(
+            channel: childChannel,
+            direction: direction,
+            openedAt: Date(),
+            activity: StreamActivityRecord(),
+            inboundGate: inboundGate ?? childChannel.eventLoop.makeSucceededVoidFuture(),
+            stream: nil,
+            negotiatedAt: nil
+        )
+        /// Drop the record whenever the channel goes away, whatever closed it. Registered here rather
+        /// than on the successful-upgrade path so streams that never negotiate get cleaned up too.
+        childChannel.closeFuture.whenComplete { [weak self] _ in
+            self?.streamRecords.removeValue(forKey: key)
+        }
+    }
+
+    /// - Note: Must be called on `self.eventLoop`.
+    private func untrackStream(on childChannel: Channel) {
+        self.streamRecords.removeValue(forKey: ObjectIdentifier(childChannel))
+    }
+
+    /// - Note: Must be called on `self.eventLoop`.
+    private func activityRecord(for childChannel: Channel) -> StreamActivityRecord? {
+        self.streamRecords[ObjectIdentifier(childChannel)]?.activity
+    }
+
+    /// The pre-negotiation gate verdict for a stream.
+    ///
+    /// A missing record means the stream was already torn down (a rejection that landed before
+    /// negotiation completed clears it), so treat that as a rejection too rather than letting the
+    /// stream through on a technicality.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func inboundGate(for childChannel: Channel) -> EventLoopFuture<Void> {
+        guard let record = self.streamRecords[ObjectIdentifier(childChannel)] else {
+            return childChannel.eventLoop.makeFailedFuture(
+                Errors.streamRejectedByGater(reason: "stream was torn down before it finished negotiating")
+            )
+        }
+        return record.inboundGate
+    }
+
+    /// Attach the muxer's `Stream` to our record and stamp the negotiation time.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func resolveTrackedStream(_ stream: LibP2PCore.Stream, on childChannel: Channel) {
+        let key = ObjectIdentifier(childChannel)
+        guard var record = self.streamRecords[key] else { return }
+        record.stream = stream
+        record.negotiatedAt = Date()
+        self.streamRecords[key] = record
+    }
+
+    /// Schedule a prune
+    /// - Note: Must be called on `self.eventLoop`.
+    private func armPruneSweep() {
+        guard let interval = self.streamPruner.sweepInterval else {
+            self.logger.trace("StreamPruner disabled sweeping; not scheduling a sweep task")
+            return
+        }
+        guard self.pruneSweepTask == nil else { return }
+        self.logger.trace("Sweeping for prunable streams every \(interval.asSeconds)s")
+        self.pruneSweepTask = self.eventLoop.scheduleRepeatedTask(initialDelay: interval, delay: interval) {
+            [weak self] _ in
+            self?.sweepForPrunableStreams()
+        }
+    }
+
+    private func cancelPruneSweep() {
+        self.pruneSweepTask?.cancel()
+        self.pruneSweepTask = nil
+    }
+
+    /// Whether a prune sweep is currently armed.
+    /// - Note: `internal` only so tests can assert we neither leak nor skip the sweep.
+    internal var hasPruneSweepScheduled: Bool {
+        self.pruneSweepTask != nil
+    }
+
+    /// Arms the sweep without going through a full security + muxer upgrade.
+    /// - Note: `internal` only so tests can exercise the scheduling decision directly.
+    internal func armPruneSweepForTesting() {
+        self.armPruneSweep()
+    }
+
+    /// One pruning pass: snapshot on the loop, decide on the actor, apply back on the loop.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func sweepForPrunableStreams() {
+        guard self.stats.status != .closing, self.stats.status != .closed else { return }
+        guard !self.streamRecords.isEmpty else { return }
+
+        let snapshots = self.streamRecords.map { key, record in
+            StreamLivenessSnapshot(
+                key: key,
+                id: record.stream?.id ?? 0,
+                direction: record.direction,
+                state: record.stream?.streamState ?? .initialized,
+                protocolCodec: record.stream?.protocolCodec ?? "",
+                openedAt: record.openedAt,
+                negotiatedAt: record.negotiatedAt,
+                lastActivityAt: record.activity.lastActivityAt
+            )
+        }
+
+        let pruner = self.streamPruner
+        let now = Date()
+        let eventLoop = self.eventLoop
+        Task { [weak self] in
+            let actions = await pruner.prune(snapshots, now: now)
+            guard !actions.isEmpty else { return }
+            eventLoop.execute {
+                self?.applyPruneActions(actions)
+            }
+        }
+    }
+
+    /// Apply the results of the pruner (closing / reseting the streams)
+    /// - Note: Must be called on `self.eventLoop`.
+    private func applyPruneActions(_ actions: [ObjectIdentifier: StreamPruneAction]) {
+        for (key, action) in actions {
+            /// The record may already be gone — the stream could have closed while the pruner was
+            /// deciding — so re-resolve rather than trusting the snapshot.
+            guard let record = self.streamRecords.removeValue(forKey: key) else { continue }
+            guard record.channel.isActive else { continue }
+
+            let description =
+                "Stream[\(record.stream?.id.description ?? "?")][\(record.stream?.protocolCodec ?? "unnegotiated")][\(record.direction)]"
+            self.logger.debug("Pruning \(description) (\(action))")
+
+            switch action {
+            case .reset:
+                if let stream = record.stream {
+                    let _ = stream.reset()
+                } else {
+                    self.muxer?.removeStream(channel: record.channel)
+                }
+            case .close:
+                if let stream = record.stream {
+                    let _ = stream.close(gracefully: true)
+                } else {
+                    self.muxer?.removeStream(channel: record.channel)
+                }
+            }
+        }
+    }
+
+    // MARK: - Opening streams
+
+    public func newStream(_ protos: [String]) -> EventLoopFuture<LibP2PCore.Stream> {
+        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
+
+    public enum NewStreamMode {
+        case openStream
+        case ifOneDoesntAlreadyExist
+        case ifOutboundDoesntAlreadyExist
+    }
+
+    private struct StreamCache {
+        let proto: String
+        let responder: Responder
+
+        init(proto: String, responder: Responder) {
+            self.proto = proto
+            self.responder = responder
+        }
+    }
+
+    private var newStreamCache: [StreamCache] = []
+    private var pendingStreamCache: [StreamCache] = []
+
+    /// Opens an outbound stream delegating to a uniquely specified handler / responder
+    public func newStream(
+        forProtocol proto: String,
+        withHandlers: HandlerConfig = .rawHandlers([]),
+        andMiddleware: MiddlewareConfig = .custom(nil),
+        closure: @escaping (@Sendable (Request) throws -> EventLoopFuture<RawResponse>)
+    ) {
+        self.logger.trace(
+            "Constructing Responder with Handlers: [\(withHandlers.handlers(application: self.application, connection: self, forProtocol: proto))]"
+        )
+
+        self.newStream(
+            forProtocol: proto,
+            withResponder: BasicResponder(
+                closure: closure,
+                handlers: withHandlers.handlers(application: self.application, connection: self, forProtocol: proto)
+            )
+        )
+    }
+
+    /// Opens an outbound stream delegating to our registered Route handler instead of a uniquely
+    /// specified handler / responder
+    public func newStream(forProtocol proto: String) {
+        self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+    }
+
+    public func newStream(forProtocol proto: String, mode: NewStreamMode = .openStream) {
+        switch mode {
+        case .openStream:
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        case .ifOneDoesntAlreadyExist:
+            guard self.hasStream(forProtocol: proto, direction: nil) == nil else { return }
+            guard !self.pendingStreamCache.contains(where: { $0.proto == proto }) else { return }
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        case .ifOutboundDoesntAlreadyExist:
+            guard self.hasStream(forProtocol: proto, direction: .outbound) == nil else { return }
+            guard !self.pendingStreamCache.contains(where: { $0.proto == proto }) else { return }
+            self.newStream(forProtocol: proto, withResponder: self.application.responder.current)
+        }
+    }
+
+    private func newStream(forProtocol proto: String, withResponder responder: Responder) {
+        let pendingStream = StreamCache(
+            proto: proto,
+            responder: responder
+        )
+
+        self.eventLoop.execute {
+            /// If the connection has already closed (e.g. a coalesced cold dial whose shared
+            /// connection failed to upgrade), fail fast instead of queueing a stream that will never
+            /// open and would otherwise only surface as a timeout.
+            guard self.stats.status != .closed && self.stats.status != .closing else {
+                self.logger.debug("Refusing new `\(proto)` stream — connection is \(self.stats.status)")
+                self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
+                return
+            }
+            /// Cancel and clear our idleTimeoutTask if we have one
+            self.cancelTimeoutTask()
+            /// Ask our muxer to open the stream...
+            if self.isMuxed, let mux = self.muxer {
+                /// Store our responder
+                self.logger.trace("Adding `\(proto)` to our newStreamCache")
+                self.newStreamCache.append(pendingStream)
+                /// Ask our installed Muxer to open / initialize a new stream for us...
+                self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
+                do {
+                    let streamFuture = try mux.newStream(channel: self.channel, proto: proto)
+                    streamFuture.whenFailure { error in
+                        self.logger.error("Muxer failed to open new stream for protocol `\(proto)`: \(error)")
+                    }
+                } catch {
+                    self.logger.error("Muxer threw while opening new stream for protocol `\(proto)`: \(error)")
+                }
+
+            } else {
+                /// Store our responder
+                self.logger.trace("Adding `\(proto)` to our pendingStreamCache")
+                self.pendingStreamCache.append(pendingStream)
+            }
+        }
+    }
+
+    /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
+    /// `newRequest`) fails immediately instead of waiting for a timeout.
+    private func fail(_ stream: StreamCache, with error: Error) {
+        let errorRequest = Request(
+            application: self.application,
+            event: .error(error),
+            streamDirection: .outbound,
+            connection: self,
+            channel: self.channel,
+            logger: self.logger,
+            on: self.channel.eventLoop
+        )
+        let _ = stream.responder.respond(to: errorRequest)
+    }
+
+    /// Fails and clears every stream still waiting to be opened. Invoked when the connection closes
+    /// before it finished upgrading, so any queued (including coalesced cold-dial) requests fail fast.
+    private func failQueuedStreams(_ error: Error) {
+        let queued = self.pendingStreamCache + self.newStreamCache
+        self.pendingStreamCache = []
+        self.newStreamCache = []
+        guard !queued.isEmpty else { return }
+        self.logger.debug("Failing \(queued.count) queued stream(s) due to: \(error)")
+        for stream in queued {
+            self.fail(stream, with: error)
+        }
+    }
+
+    public func newStreamSync(_ proto: String) throws -> LibP2PCore.Stream {
+        let stream: _Stream
+        if isMuxed, let mux = self.muxer {
+            // A synchronous API must never block the very event loop it depends on to make
+            // progress — doing so would deadlock. Callers on the loop must use the async
+            // `newStream(_:)` / `newStream(forProtocol:)` APIs instead.
+            guard !self.channel.eventLoop.inEventLoop else {
+                throw Application.Connections.Errors.cannotBlockEventLoop
+            }
+            // Ask our installed Muxer to open / initialize a new stream for us...
+            self.logger.debug("Asking Muxer to open / initialize new stream")
+            stream = try mux.newStream(channel: self.channel, proto: proto).wait()
+        } else {
+            // Initialize a Stream to be opened once our Muxer is installed...
+            self.logger.debug("TODO: Store new stream to be open later, once a muxer has been installed")
+            throw Application.Connections.Errors.notImplementedYet
+        }
+
+        stream._connection.withLockedValue { $0 = self }
+
+        self.registry[stream.id] = stream
+
+        return stream
+    }
+
+    public func newStreamHandlerSync(_ proto: String) throws -> StreamHandler {
+        throw Application.Connections.Errors.notImplementedYet
+    }
+
+    public func removeStream(id: UInt64) -> EventLoopFuture<Void> {
+        if let stream = self.registry.removeValue(forKey: id) {
+            return stream.close(gracefully: true)
+        } else {
+            return self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.noStreamForID(id))
+        }
+    }
+
+    public func acceptStream(_ stream: LibP2PCore.Stream, protocol: String, metadata: [String]) -> EventLoopFuture<Bool>
+    {
+        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
+
+    public func hasStream(forProtocol proto: String, direction: ConnectionStats.Direction? = nil) -> LibP2PCore.Stream?
+    {
+        if let direction = direction {
+            return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) && ($0.direction == direction) })
+        } else {
+            return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) })
+        }
+    }
+
+    // MARK: - Closing
+
+    /// Called as soon as there is a request to close the Connection (internally via the connection
+    /// manager, or externally via the user)
+    internal func onClosing() -> EventLoopFuture<Void> {
+        eventLoop.submit {
+            self.stats.status = .closing
+            self.logger.trace("Closing")
+        }
+    }
+
+    public func close() -> EventLoopFuture<Void> {
+        self.registry = [:]
+        self.cancelTimeoutTask()
+        self.cancelPruneSweep()
+        self.logger.trace("Close called, attempting to close all streams before shutting down the channel.")
+        return eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
+            self.onClosing().flatMap { () -> EventLoopFuture<Void> in
+                let closePromise = self.eventLoop.makePromise(of: Void.self)
+                let timeout = self.eventLoop.scheduleTask(in: .seconds(1)) {
+                    closePromise.fail(Application.Connections.Errors.failedToCloseAllStreams)
+                }
+
+                closePromise.completeWith(
+                    self.streams.map { $0.close(gracefully: true) }.flatten(on: self.eventLoop).flatMapAlways {
+                        result -> EventLoopFuture<Void> in
+                        timeout.cancel()
+                        switch result {
+                        case .failure(let err):
+                            self.logger.error("Error encountered while attempting to close streams: \(err)")
+                            return self.eventLoop.makeFailedFuture(
+                                Application.Connections.Errors.failedToCloseAllStreams
+                            )
+                        case .success:
+                            return self.streams.compactMap {
+                                switch $0.streamState {
+                                case .closed, .reset:
+                                    return nil
+                                default:
+                                    // Ensure we fire our close event before
+                                    // TODO: Silently force close the stream...
+                                    self.logger.warning(
+                                        "Force Closing Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)]"
+                                    )
+                                    return $0.on?(.closed)
+                                }
+                            }.flatten(on: self.eventLoop)
+                        }
+                    }
+                )
+
+                return closePromise.futureResult.flatMapAlways { res in
+                    self.stats.status = .closed
+                    switch res {
+                    case .success:
+                        self.logger.trace("All Streams closed cleanly")
+                    case .failure:
+                        self.logger.warning("Failed to close all Streams cleanly")
+                    }
+                    // Do any additional clean up before closing / deiniting self...
+                    self.logger.trace("Proceeding to close Connection")
+                    return self.channel.close(mode: .all)
+                }
+            }
+        }
+    }
+
+    public enum Errors: Error {
+        /// A ``StreamGater`` refused a stream.
+        case streamRejectedByGater(reason: String)
+    }
+}
+
+// MARK: - State machine
+
+extension BaseConnection {
+
+    public struct ConnectionStateMachine {
+        internal private(set) var state: ConnectionState
+
+        internal init() {
+            self.state = .raw
+        }
+
+        internal mutating func secureConnection() throws {
+            switch state {
+            case .raw:
+                self.state = .secured
+            case .secured, .muxed, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+
+        internal mutating func muxConnection() throws {
+            switch state {
+            case .secured:
+                self.state = .muxed
+            case .raw, .muxed, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+
+        internal mutating func upgradeConnection() throws {
+            switch state {
+            case .muxed:
+                self.state = .upgraded
+            case .raw, .secured, .upgraded, .closed:
+                throw StateTransitionError.invalidStateTransition
+            }
+        }
+
+        internal mutating func closeConnection() throws {
+            switch state {
+            case .closed:
+                break
+            case .raw, .secured, .muxed, .upgraded:
+                self.state = .closed
+            }
+        }
+    }
+
+    internal enum StateTransitionError: Error {
+        case invalidStateTransition
+    }
+}
+
+// MARK: - Activity
+
+extension BaseConnection {
+    public func lastActivity() -> Date {
+        guard !(self.status == .closed || self.status == .closing) else {
+            if let upgraded = self.stats.timeline.history.first(where: { $0.key == .upgraded }) {
+                return upgraded.value
+            }
+            return Date.distantPast
+        }
+        let lastConnectionActivity = self.stats.timeline.history.max(by: { lhs, rhs in
+            lhs.value < rhs.value
+        })?.value
+        let lastStreamActivity = self.streamHistory.max(by: { lhs, rhs in
+            lhs.date < rhs.date
+        })?.date
+
+        switch (lastConnectionActivity, lastStreamActivity) {
+        case (nil, nil):
+            return Date.distantPast
+        case (.some(let connActivity), nil):
+            return connActivity
+        case (nil, .some(let strActivity)):
+            return strActivity
+        case (.some(let connActivity), .some(let strActivity)):
+            return connActivity < strActivity ? strActivity : connActivity
+        }
+    }
+
+    public var lastActive: TimeAmount {
+        .seconds(Int64(Date().timeIntervalSince(self.lastActivity())))
+    }
+}
+
+// MARK: - Description
+
+extension BaseConnection {
+    public var description: String {
+        let header =
+            "--- 🔁 \(self.direction == .inbound ? "Inbound" : "Outbound") Connection[\(self.id.uuidString.prefix(5))] 🔁 ---"
+        return """
+            \(header)
+            State: \(self.state) <\(self.status)>
+            Peer: \(self.remoteAddr?.description ?? "???") <\(self.remotePeer?.b58String ?? "???")>
+            Timeline:
+             - \(self.timeline.sorted(by: { $0.value < $1.value }).map { "\($0.value) - \($0.key)" }.joined(separator: "\n - "))
+            Streams: Open<\(self.streams.filter({ $0.streamState == .open }).count)>, Total<\(self.streams.count)>
+             - \(self.streamHistory.sorted(by: { $0.date < $1.date }).map { "[\($0.state)][\($0.direction)]\($0.proto) @ \($0.date.timeIntervalSince1970)" }.joined(separator: "\n - "))
+            Last Activity: \(self.lastActivity())
+            \(String(repeating: "-", count: header.count + 2))\n
+            """
+    }
+}

--- a/Sources/LibP2P/Connections/Gating/StreamActivityRecord.swift
+++ b/Sources/LibP2P/Connections/Gating/StreamActivityRecord.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2PCore
+import NIOConcurrencyHelpers
+
+/// The last moment a single muxed stream actually moved bytes in either direction.
+///
+/// This is included in our Response Encoder / Decoder to update everytime bytes are actually moved
+/// along a `Stream`. This gives us insight into wether a `Stream` is sitting idle or not.
+///
+/// - Note: Reads and writes on a stream are confined to that stream's event loop, but the pruner's
+///   sweep reads this value after a hop through an `actor`, hence the lock rather than a bare `var`.
+final class StreamActivityRecord: Sendable {
+    private let lastActivity: NIOLockedValueBox<Date?>
+
+    init() {
+        self.lastActivity = .init(nil)
+    }
+
+    /// Stamps "bytes moved just now". Called from the stream's pipeline.
+    func touch() {
+        self.lastActivity.withLockedValue { $0 = Date() }
+    }
+
+    /// The last time bytes moved, or `nil` if this stream has never exchanged any.
+    var lastActivityAt: Date? {
+        self.lastActivity.withLockedValue { $0 }
+    }
+}

--- a/Sources/LibP2P/Connections/Gating/StreamGater.swift
+++ b/Sources/LibP2P/Connections/Gating/StreamGater.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2PCore
+
+/// The verdict a `StreamGater` returns for a stream it was asked about.
+enum StreamGateDecision: Sendable {
+    case accept
+    /// Reject the stream. The reason is logged and, for a rejected inbound stream, surfaced as the
+    /// error that closes the child channel.
+    case reject(reason: String)
+
+    var isAccepted: Bool {
+        if case .accept = self { return true }
+        return false
+    }
+}
+
+/// What we know about an inbound stream before multistream-select has picked a protocol.
+struct InboundStreamGateContext: Sendable {
+    let connectionID: UUID
+    let remotePeer: PeerID?
+    let remoteAddress: Multiaddr?
+    /// The number of streams the muxer currently has open on this connection.
+    ///
+    /// - Note: This includes the stream being gated
+    let openStreamCount: Int
+}
+
+/// What we know about a stream once multistream-select has agreed on a protocol, but before the
+/// route's handlers are installed on its pipeline.
+struct NegotiatedStreamGateContext: Sendable {
+    let connectionID: UUID
+    let remotePeer: PeerID?
+    let remoteAddress: Multiaddr?
+    let direction: ConnectionStats.Direction
+    let protocolCodec: String
+    let openStreamCount: Int
+}
+
+/// Decides which streams a ``BaseConnection`` is willing to carry.
+///
+/// - Note: Should move to `swift-libp2p-core` once the shape settles.
+protocol StreamGater: Sendable {
+    /// Called as soon as the remote opens an inbound stream, before any protocol is known.
+    ///
+    /// This runs concurrently with the connection installing the stream's multistream-select
+    /// upgrader. A `.reject` will tear down the stream before a ResposeHandler is installed. But
+    /// not necessarily before negotiation bytes have been exchanged.
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision
+
+    /// Called on every stream — inbound and outbound — once its protocol has been negotiated and
+    /// before the route's handlers are installed.
+    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision
+}
+
+extension StreamGater {
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+        .accept
+    }
+
+    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision {
+        .accept
+    }
+}
+
+/// The default, accept all, stream gater.
+actor AllowAllStreamGater: StreamGater {
+    init() {}
+}

--- a/Sources/LibP2P/Connections/Gating/StreamPruner.swift
+++ b/Sources/LibP2P/Connections/Gating/StreamPruner.swift
@@ -74,7 +74,7 @@ actor NoOpStreamPruner: StreamPruner {
 ///
 /// Four failure modes, in priority order:
 /// 1. **Already finished.** `.closed` / `.reset` streams that the muxer hasn't cleared yet.
-/// 2. **Half-closed too long.** One side hung up and the other never followed suite, reset rather than wait.
+/// 2. **Half-closed too long.** One side closed and the other never followed suite, reset rather than wait.
 /// 3. **Never upgraded.** The remote opened a stream and never agreed on a protocol.
 /// 4. **Idle.** A negotiated stream that hasn't moved a byte in ``Configuration/dataIdleTimeout``.
 actor IdleTimeoutStreamPruner: StreamPruner {

--- a/Sources/LibP2P/Connections/Gating/StreamPruner.swift
+++ b/Sources/LibP2P/Connections/Gating/StreamPruner.swift
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2PCore
+
+/// A stream's observable liveness.
+///
+/// - Note: Keyed by `ObjectIdentifier(stream.channel)` rather than by `id`, because muxer stream IDs
+///   are only unique per direction.
+struct StreamLivenessSnapshot: Sendable {
+    let key: ObjectIdentifier
+    let id: UInt64
+    let direction: ConnectionStats.Direction
+    let state: StreamState
+    /// The negotiated protocol, or `""` if multistream-select hasn't finished yet.
+    let protocolCodec: String
+    /// When the connection first learned about this stream.
+    let openedAt: Date
+    /// When a protocol was agreed, or `nil` while the stream is still upgrading.
+    let negotiatedAt: Date?
+    /// When bytes last moved in either direction, or `nil` if none ever have.
+    let lastActivityAt: Date?
+}
+
+/// How a stream should be evicted.
+enum StreamPruneAction: Sendable {
+    /// Close gracefully
+    case close
+    /// Reset
+    case reset
+}
+
+/// Decides which of a connection's streams should be evicted.
+///
+/// The StreamPruner operates on a snapshot of the Connection's streams so one instance can be shared
+/// across all Connections. It also makes the pruners implementation easier and testable.
+///
+/// - Note: Should move to `swift-libp2p-core` eventually.
+protocol StreamPruner: Sendable {
+    /// How often the connection should sweep. `nil` disables sweeping entirely
+    var sweepInterval: TimeAmount? { get }
+
+    /// Given every stream on a connection, return only those that should be evicted.
+    ///
+    /// Streams absent from the returned dictionary are kept.
+    func prune(_ streams: [StreamLivenessSnapshot], now: Date) async -> [ObjectIdentifier: StreamPruneAction]
+}
+
+/// The simplest possible pruner: never prunes, and never asks to be scheduled.
+///
+/// Matches the behaviour of `ARCConnection` / `BasicConnectionLight`, neither of which prunes streams.
+actor NoOpStreamPruner: StreamPruner {
+    init() {}
+
+    nonisolated var sweepInterval: TimeAmount? { nil }
+
+    func prune(_ streams: [StreamLivenessSnapshot], now: Date) async -> [ObjectIdentifier: StreamPruneAction] {
+        [:]
+    }
+}
+
+/// Evicts streams that have stopped being useful.
+///
+/// Four failure modes, in priority order:
+/// 1. **Already finished.** `.closed` / `.reset` streams that the muxer hasn't cleared yet.
+/// 2. **Half-closed too long.** One side hung up and the other never followed suite, reset rather than wait.
+/// 3. **Never upgraded.** The remote opened a stream and never agreed on a protocol.
+/// 4. **Idle.** A negotiated stream that hasn't moved a byte in ``Configuration/dataIdleTimeout``.
+actor IdleTimeoutStreamPruner: StreamPruner {
+
+    struct Configuration: Sendable {
+        /// How long a stream may sit without agreeing on a protocol.
+        ///
+        /// Kept comfortably inside `Application.Connections.defaultUpgradeTimeout` (15s), so a
+        /// connection whose streams all stall here is still cleared by the connection manager if the
+        /// connection itself never upgrades.
+        var negotiationTimeout: TimeAmount = .seconds(10)
+
+        /// How long a negotiated stream may sit without moving a byte.
+        var dataIdleTimeout: TimeAmount = .seconds(60)
+
+        /// How long a half-closed stream may sit before we reset it outright.
+        var closingGrace: TimeAmount = .seconds(3)
+
+        /// How often the owning connection should sweep. `nil` disables sweeping.
+        var sweepInterval: TimeAmount? = .seconds(1)
+
+        init(
+            negotiationTimeout: TimeAmount = .seconds(10),
+            dataIdleTimeout: TimeAmount = .seconds(60),
+            closingGrace: TimeAmount = .seconds(3),
+            sweepInterval: TimeAmount? = .seconds(1)
+        ) {
+            self.negotiationTimeout = negotiationTimeout
+            self.dataIdleTimeout = dataIdleTimeout
+            self.closingGrace = closingGrace
+            self.sweepInterval = sweepInterval
+        }
+    }
+
+    let configuration: Configuration
+
+    /// Running total of streams this pruner has asked to evict, across every connection sharing it.
+    /// Exposed for diagnostics and to let tests assert a sweep actually did something.
+    private(set) var totalPruned: Int = 0
+
+    init(configuration: Configuration = .init()) {
+        self.configuration = configuration
+    }
+
+    /// `nonisolated` because the connection reads it synchronously when scheduling its sweep, and it
+    /// only ever reads an immutable `Sendable` `let`.
+    nonisolated var sweepInterval: TimeAmount? { self.configuration.sweepInterval }
+
+    func prune(_ streams: [StreamLivenessSnapshot], now: Date) async -> [ObjectIdentifier: StreamPruneAction] {
+        var actions: [ObjectIdentifier: StreamPruneAction] = [:]
+        for stream in streams {
+            if let action = Self.action(for: stream, now: now, configuration: self.configuration) {
+                actions[stream.key] = action
+            }
+        }
+        self.totalPruned += actions.count
+        return actions
+    }
+
+    static func action(
+        for stream: StreamLivenessSnapshot,
+        now: Date,
+        configuration: Configuration
+    ) -> StreamPruneAction? {
+        switch stream.state {
+        case .closed, .reset:
+            // Terminal, but still on the books — evict so the muxer and our bookkeeping agree.
+            return .close
+
+        case .receiveClosed, .writeClosed:
+            // Half-closed. If the other side hasn't followed within the grace period, stop waiting.
+            // Use `lastActivityAt` when available, fallback to state changes if not
+            let since = stream.lastActivityAt ?? stream.negotiatedAt ?? stream.openedAt
+            return now.timeIntervalSince(since) > configuration.closingGrace.asSeconds ? .reset : nil
+
+        case .initialized, .open:
+            guard let negotiatedAt = stream.negotiatedAt else {
+                // Never agreed on a protocol. Nothing is installed on its pipeline, so reset it.
+                return now.timeIntervalSince(stream.openedAt) > configuration.negotiationTimeout.asSeconds
+                    ? .reset
+                    : nil
+            }
+            // Ensure that the stream isn't sittle idle
+            let since = stream.lastActivityAt ?? negotiatedAt
+            return now.timeIntervalSince(since) > configuration.dataIdleTimeout.asSeconds ? .close : nil
+        }
+    }
+}

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -75,10 +75,18 @@ extension Application {
             /// peer and the network stack, concurrent dials to the same ma coalesce onto a single pending
             /// connection, while dials to a different ma each get their own independent dial.
             let dialsInFlight: NIOLockedValueBox<[String: EventLoopFuture<AppConnection>]>
+            /// Decides which streams a `BaseConnection` will carry. Unused by `ARCConnection` and
+            /// `BasicConnectionLight`, neither of which gates streams.
+            let streamGater: NIOLockedValueBox<StreamGater>
+            /// Decides which of a `BaseConnection`'s streams get evicted. Unused by `ARCConnection` and
+            /// `BasicConnectionLight`, neither of which prunes streams.
+            let streamPruner: NIOLockedValueBox<StreamPruner>
             init() {
                 self.manager = .init(nil)
-                self.connType = .init(ARCConnection.self)
+                self.connType = .init(BaseConnection.self)
                 self.dialsInFlight = .init([:])
+                self.streamGater = .init(AllowAllStreamGater())
+                self.streamPruner = .init(IdleTimeoutStreamPruner())
             }
         }
 
@@ -99,10 +107,36 @@ extension Application {
         }
 
         /// Specify the type of AppConnection to use when establishing a Connection to a remote peer.
-        /// Note: The built in options are `BasicConnectionLight` and `ARCConnection`
+        /// Note: The built in options are `BaseConnection`, `BasicConnectionLight` and `ARCConnection`
         /// Note: There's also a `DummyConnection` available for embedded testing.
         public func use(connectionType: AppConnection.Type) {
             self.storage.connType.withLockedValue { $0 = connectionType }
+        }
+
+        /// Specify the `StreamGater` a `BaseConnection` consults before accepting a stream.
+        ///
+        /// - Note: Only observed by Connections created *after* this call, and only by
+        ///   `BaseConnection` — the legacy Connection types don't gate streams.
+        func use(streamGater: StreamGater) {
+            self.storage.streamGater.withLockedValue { $0 = streamGater }
+        }
+
+        /// Specify the `StreamPruner` a `BaseConnection` uses to evict dead streams.
+        ///
+        /// - Note: Only observed by Connections created *after* this call, and only by
+        ///   `BaseConnection` — the legacy Connection types don't prune streams.
+        func use(streamPruner: StreamPruner) {
+            self.storage.streamPruner.withLockedValue { $0 = streamPruner }
+        }
+
+        /// The currently configured `StreamGater`, resolved by `BaseConnection` at init time.
+        var streamGater: StreamGater {
+            self.storage.streamGater.withLockedValue { $0 }
+        }
+
+        /// The currently configured `StreamPruner`, resolved by `BaseConnection` at init time.
+        var streamPruner: StreamPruner {
+            self.storage.streamPruner.withLockedValue { $0 }
         }
 
         let application: Application

--- a/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
+++ b/Sources/LibP2P/Connections/Managers/Application+ConnectionManager.swift
@@ -115,16 +115,14 @@ extension Application {
 
         /// Specify the `StreamGater` a `BaseConnection` consults before accepting a stream.
         ///
-        /// - Note: Only observed by Connections created *after* this call, and only by
-        ///   `BaseConnection` — the legacy Connection types don't gate streams.
+        /// - Note: Only observed by Connections created *after* this call
         func use(streamGater: StreamGater) {
             self.storage.streamGater.withLockedValue { $0 = streamGater }
         }
 
         /// Specify the `StreamPruner` a `BaseConnection` uses to evict dead streams.
         ///
-        /// - Note: Only observed by Connections created *after* this call, and only by
-        ///   `BaseConnection` — the legacy Connection types don't prune streams.
+        /// - Note: Only observed by Connections created *after* this call
         func use(streamPruner: StreamPruner) {
             self.storage.streamPruner.withLockedValue { $0 = streamPruner }
         }

--- a/Sources/LibP2P/Request/RequestEncoderChannelHandler.swift
+++ b/Sources/LibP2P/Request/RequestEncoderChannelHandler.swift
@@ -24,6 +24,8 @@ final class RequestEncoderChannelHandler: ChannelInboundHandler, RemovableChanne
     private let logger: Logger
     private let `protocol`: String
     private let direction: ConnectionStats.Direction
+    /// Set only by `BaseConnection`, whose `StreamPruner` needs to know when this stream last moved bytes.
+    private let activity: StreamActivityRecord?
 
     private var hasSentIsReady: Bool = false
 
@@ -32,13 +34,15 @@ final class RequestEncoderChannelHandler: ChannelInboundHandler, RemovableChanne
         connection: Connection,
         protocol: String,
         logger: Logger,
-        direction: ConnectionStats.Direction
+        direction: ConnectionStats.Direction,
+        activity: StreamActivityRecord? = nil
     ) {
         self.app = application
         self.connection = connection
         self.logger = logger
         self.protocol = `protocol`
         self.direction = direction
+        self.activity = activity
     }
 
     func handlerAdded(context: ChannelHandlerContext) {
@@ -51,6 +55,8 @@ final class RequestEncoderChannelHandler: ChannelInboundHandler, RemovableChanne
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let inboundBytes = self.unwrapInboundIn(data)
+
+        self.activity?.touch()
 
         // Ensure we fire the .ready event before sending data down the pipeline
         if self.hasSentIsReady == false {

--- a/Sources/LibP2P/Response/ResponseDecoderChannelHandler.swift
+++ b/Sources/LibP2P/Response/ResponseDecoderChannelHandler.swift
@@ -23,20 +23,25 @@ final class ResponseDecoderChannelHandler: ChannelOutboundHandler, RemovableChan
     typealias OutboundOut = ByteBuffer
 
     private let logger: Logger
+    /// Set only by `BaseConnection`, whose `StreamPruner` needs to know when this stream last moved bytes.
+    private let activity: StreamActivityRecord?
 
-    init(logger: Logger) {
+    init(logger: Logger, activity: StreamActivityRecord? = nil) {
         self.logger = logger
+        self.activity = activity
     }
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let response = self.unwrapOutboundIn(data)
 
-        /// Extract the bytes
+        self.activity?.touch()
+
+        // Extract the bytes
         let payload = response.payload
 
         self.logger.trace("ResponseDecoderChannelHandler: write() called")
 
-        /// Pass it along
+        // Pass it along
         context.writeAndFlush(self.wrapOutboundOut(payload), promise: promise)
     }
 

--- a/Sources/LibP2PTesting/ModuleHarness/MockMuxer/Stream/MockMuxStreamChannel.swift
+++ b/Sources/LibP2PTesting/ModuleHarness/MockMuxer/Stream/MockMuxStreamChannel.swift
@@ -511,9 +511,7 @@ internal final class MockMuxStreamChannel: Channel, ChannelCore, @unchecked Send
             } else {
                 self.multiplexer.childChannelClosed(channelID: ObjectIdentifier(self))
             }
-            self._pipeline = nil
             self.pendingReads.removeAll()
-            self.pendingReads = nil
         }
     }
 

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -36,8 +36,6 @@ extension LibP2PTests {
 
         // MARK: - Connection creation
 
-        /// A freshly instantiated connection starts in the `raw` state, unmuxed, with no streams, and with
-        /// its addressing / peer metadata wired up from the constructor arguments.
         @Test("A new connection starts raw, unmuxed, and stream-less")
         func testNewConnectionInitialState() async throws {
             try await withApp { app in
@@ -45,7 +43,7 @@ extension LibP2PTests {
                 defer { _ = try? channel.finish() }
                 let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
-                let connection = BasicConnectionLight(
+                let connection = BaseConnection(
                     application: app,
                     channel: channel,
                     direction: .outbound,
@@ -68,15 +66,14 @@ extension LibP2PTests {
 
         // MARK: - Connection destruction
 
-        /// When the underlying channel closes, the connection must tear itself down: mark itself `closed`,
-        /// drop its muxer, and empty its stream registry — the real-world path taken when a peer drops.
+        /// When the underlying channel closes, the connection must tear itself down.
         @Test("Closing the underlying channel drives connection teardown")
         func testConnectionTeardownOnChannelClose() async throws {
             try await withApp { app in
                 let channel = NIOAsyncTestingChannel()
                 let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
-                let connection = BasicConnectionLight(
+                let connection = BaseConnection(
                     application: app,
                     channel: channel,
                     direction: .outbound,
@@ -84,11 +81,6 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
 
-                // Close the channel so the connection's teardown handler fires. `NIOAsyncTestingChannel` is
-                // backed by a thread-safe `NIOAsyncTestingEventLoop`, so the connection's event-loop-bound
-                // promises can be safely failed from its `deinit` on whatever thread releases it — unlike an
-                // `EmbeddedEventLoop`, which asserts when touched off its creating thread. `finish()` closes
-                // the channel and drives the loop to completion.
                 _ = try await channel.finish()
 
                 #expect(connection.status == .closed)
@@ -100,55 +92,45 @@ extension LibP2PTests {
 
         // MARK: - Sub-stream creation & closing
 
-        /// The blocking `newStreamSync` API must refuse to run on the connection's own event loop — doing
-        /// so would deadlock, since the call blocks the very loop the muxer needs to make progress. This
-        /// guards the deadlock trap fixed in the connection layer.
+        /// The blocking `newStreamSync` API must refuse to run on the connection's own event loop.
         @Test("newStreamSync refuses to block the connection's event loop")
         func testNewStreamSyncRejectedOnEventLoop() async throws {
             try await withApp { app in
                 let channel = EmbeddedChannel()
                 defer { _ = try? channel.finish() }
-                let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
-                let connection = BasicConnectionLight(
+                let connection = BaseConnection(
                     application: app,
                     channel: channel,
                     direction: .outbound,
-                    remoteAddress: remote,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
                     expectedRemotePeer: nil
                 )
 
-                // Stand in a muxer so the connection believes it has been upgraded. `muxer` is a weak
-                // reference on the connection, so the test holds a strong reference for the duration.
                 let muxer = MockMuxer(eventLoop: channel.eventLoop)
                 connection.muxer = muxer
                 connection.isMuxed = true
 
-                // An `EmbeddedChannel` reports `inEventLoop == true`, so the blocking API must bail out.
                 #expect(throws: Application.Connections.Errors.self) {
                     _ = try connection.newStreamSync("/echo/1.0.0")
                 }
-                _ = muxer  // keep the muxer alive for the duration of the call
+                _ = muxer  // keep the (weakly-held) muxer alive for the duration of the call
             }
         }
 
         /// Closing a muxed connection must close each of its open sub-streams before tearing down the
-        /// underlying channel. Here a stand-in muxer holds one open stream; after `close()` that stream
-        /// must be driven to `.closed` and the connection's channel must be inactive.
+        /// underlying channel.
         @Test("Closing a connection closes its open sub-streams")
         func testConnectionClosesItsSubStreams() async throws {
             try await withApp { app in
-                // Share a single embedded loop across the connection and its stream so cross-loop future
-                // chaining inside `close()` resolves deterministically when we run the loop.
                 let loop = EmbeddedEventLoop()
                 let channel = EmbeddedChannel(loop: loop)
-                let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
-                let connection = BasicConnectionLight(
+                let connection = BaseConnection(
                     application: app,
                     channel: channel,
                     direction: .outbound,
-                    remoteAddress: remote,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
                     expectedRemotePeer: nil
                 )
 
@@ -160,7 +142,6 @@ extension LibP2PTests {
                 #expect(connection.streams.count == 1)
                 #expect(stream.streamState == .open)
 
-                // Drive the production close path, running the loop so its submitted work resolves.
                 let closeFuture: EventLoopFuture<Void> = connection.close()
                 loop.run()
                 try await closeFuture.get()
@@ -172,20 +153,42 @@ extension LibP2PTests {
             }
         }
 
-        /// Asking a connection to remove a stream ID it never knew about must surface a clean, typed error
-        /// rather than trapping.
+        /// `BasicConnectionLight.close()` forgot to mark itself `.closed`; `ARCConnection` didn't. The
+        /// collapsed type must keep ARC's (correct) behaviour, since `pruneOldConnections` reads it.
+        @Test("close() marks the connection closed")
+        func testCloseMarksStatusClosed() async throws {
+            try await withApp { app in
+                let loop = EmbeddedEventLoop()
+                let channel = EmbeddedChannel(loop: loop)
+
+                let connection = BaseConnection(
+                    application: app,
+                    channel: channel,
+                    direction: .outbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil
+                )
+
+                let closeFuture: EventLoopFuture<Void> = connection.close()
+                loop.run()
+                try await closeFuture.get()
+
+                #expect(connection.status == .closed)
+            }
+        }
+
+        /// Removing a stream ID the connection never knew about must surface a typed error, not trap.
         @Test("Removing an unknown stream ID fails with .noStreamForID")
         func testRemoveUnknownStreamFails() async throws {
             try await withApp { app in
                 let channel = EmbeddedChannel()
                 defer { _ = try? channel.finish() }
-                let remote = try Multiaddr("/ip4/127.0.0.1/tcp/1234")
 
-                let connection = BasicConnectionLight(
+                let connection = BaseConnection(
                     application: app,
                     channel: channel,
                     direction: .outbound,
-                    remoteAddress: remote,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
                     expectedRemotePeer: nil
                 )
 

--- a/Tests/LibP2PTests/StreamGaterTests.swift
+++ b/Tests/LibP2PTests/StreamGaterTests.swift
@@ -1,0 +1,327 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import LibP2PCore
+import LibP2PTesting
+import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+import NIOEmbedded
+import Testing
+
+@testable import LibP2P
+
+extension LibP2PTests {
+
+    @Suite("StreamGaterTests")
+    struct StreamGaterTests {
+
+        /// A gater that rejects an inbound stream must tear it down.
+        ///
+        /// The initializer future itself still *succeeds* — it has to, since it gates child-channel
+        /// activation and YAMUX reports a protocol violation for frames arriving before that. The
+        /// rejection lands separately, as soon as the gater answers, and shows up as the muxer being
+        /// asked to drop the child channel.
+        @Test("A rejected inbound stream is dropped from the muxer once the verdict lands")
+        func testRejectedInboundStreamIsTornDown() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(decision: .reject(reason: "not today"))
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = BaseConnection(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil,
+                    streamGater: gater,
+                    streamPruner: NoOpStreamPruner()
+                )
+                connection.muxer = muxer
+                connection.isMuxed = true
+
+                // The initializer's own outcome is deliberately not asserted here: the rejection can
+                // land first and close the child channel, which makes the in-flight `addHandler` fail
+                // with `.ioOnClosedChannel`. Either ordering is correct — the stream is going away.
+                // (`testASlowGaterDoesNotBlockTheInitializer` covers the non-blocking property.)
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                initialized.whenComplete { _ in }
+
+                // The verdict arrives via `eventLoop.execute` from a `Task`, so drive the loop while we
+                // poll. `NIOAsyncTestingEventLoop` is thread-safe, unlike `EmbeddedEventLoop`.
+                let droppedIt = try await driving(loop) {
+                    await waitUntilTrue { muxer.wasAskedToRemove(child) }
+                }
+                #expect(droppedIt)
+
+                #expect(await gater.inboundCallCount == 1)
+                // The gater never saw a protocol — the stream was gone before it negotiated one.
+                #expect(await gater.negotiatedCallCount == 0)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        /// The default `AllowAllStreamGater` must not change the behaviour of the connections
+        /// `BaseConnection` replaces: an accepted inbound stream proceeds to install its upgrader, and the
+        /// muxer is left alone.
+        @Test("An accepted inbound stream proceeds to protocol negotiation")
+        func testAcceptedInboundStreamInstallsUpgrader() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(decision: .accept)
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = BaseConnection(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil,
+                    streamGater: gater,
+                    streamPruner: NoOpStreamPruner()
+                )
+                connection.muxer = muxer
+                connection.isMuxed = true
+
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                try await driving(loop) { try await initialized.get() }
+
+                #expect(await gater.inboundCallCount == 1)
+                // Accepted, so nothing was torn down...
+                #expect(muxer.removedChannelCount == 0)
+                // ...and multistream-select is now on the child channel's pipeline, waiting to negotiate.
+                // Collapse the lookup to a `Bool` on the event loop: `ChannelHandlerContext` isn't
+                // `Sendable`, so it must not cross the await boundary.
+                let hasUpgrader = try await driving(loop) {
+                    try await child.pipeline.context(name: "upgrader").map { _ in true }.get()
+                }
+                #expect(hasUpgrader)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        /// YAMUX only sends its open-confirmation (moving the stream out of `.requestedRemotely`) once
+        /// this future resolves, and treats any frame arriving before that as
+        /// `YAMUX.Error.protocolViolation` — so a peer that pipelines its payload behind the stream-open
+        /// breaks the stream if we suspend here. An earlier revision awaited the gater and produced
+        /// exactly that error, across every YAMUX integration test.
+        @Test("A slow gater does not block the child-channel initializer")
+        func testASlowGaterDoesNotBlockTheInitializer() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let gater = SlowStreamGater(delay: .milliseconds(500))
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = BaseConnection(
+                    application: app,
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil,
+                    streamGater: gater,
+                    streamPruner: NoOpStreamPruner()
+                )
+                connection.muxer = muxer
+                connection.isMuxed = true
+
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                try await driving(loop) { try await initialized.get() }
+
+                // The initializer resolved; the gater hasn't even answered yet.
+                #expect(await gater.hasAnswered == false)
+                // And the stream is still alive.
+                #expect(muxer.removedChannelCount == 0)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("The AppConnection initializer picks up the app's configured gater")
+        func testConnectionResolvesGaterFromApplication() async throws {
+            try await withApp { app in
+                let gater = RecordingStreamGater(decision: .reject(reason: "configured"))
+                app.connectionManager.use(streamGater: gater)
+                app.connectionManager.use(streamPruner: NoOpStreamPruner())
+                app.connectionManager.use(connectionType: BaseConnection.self)
+
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                // Build the connection exactly the way the transports do.
+                let connection = app.connectionManager.generateConnection(
+                    channel: channel,
+                    direction: .inbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil
+                )
+                let base = try #require(connection as? BaseConnection)
+                base.muxer = muxer
+                base.isMuxed = true
+
+                // Observe the resolved gater the only way an outside caller can: drive a stream past it
+                // and watch the (rejecting) verdict tear the stream down.
+                let initialized: EventLoopFuture<Void> = base.inboundMuxedChildChannelInitializer(child)
+                initialized.whenComplete { _ in }
+                let droppedIt = try await driving(loop) {
+                    await waitUntilTrue { muxer.wasAskedToRemove(child) }
+                }
+                #expect(droppedIt)
+                #expect(await gater.inboundCallCount == 1)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        // MARK: - Helpers
+
+        /// Runs `loop` in the background while awaiting `body`.
+        ///
+        /// The gater's verdict is delivered by an `eventLoop.execute` issued from a detached `Task`, so
+        /// there's no single point at which one `loop.run()` is guaranteed to pick it up. Ticking the loop
+        /// concurrently is safe here because `NIOAsyncTestingEventLoop` is thread-safe.
+        private func driving<T>(
+            _ loop: NIOAsyncTestingEventLoop,
+            _ body: () async throws -> T
+        ) async throws -> T {
+            let ticker = Task {
+                while !Task.isCancelled {
+                    await loop.run()
+                    try? await Task.sleep(for: .milliseconds(1))
+                }
+            }
+            defer { ticker.cancel() }
+            return try await body()
+        }
+
+        /// Polls `predicate` until it holds or the attempts run out. Needed because a gater's verdict —
+        /// and the teardown it triggers — land asynchronously, off the calling task.
+        private func waitUntilTrue(
+            attempts: Int = 200,
+            every: Duration = .milliseconds(5),
+            _ predicate: () -> Bool
+        ) async -> Bool {
+            for _ in 0..<attempts {
+                if predicate() { return true }
+                try? await Task.sleep(for: every)
+            }
+            return predicate()
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+/// A `StreamGater` that returns a fixed verdict and records how often, and about what, it was asked.
+actor RecordingStreamGater: StreamGater {
+    private let decision: StreamGateDecision
+    private(set) var inboundCallCount = 0
+    private(set) var negotiatedCallCount = 0
+    private(set) var negotiatedProtocols: [String] = []
+
+    init(decision: StreamGateDecision) {
+        self.decision = decision
+    }
+
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+        self.inboundCallCount += 1
+        return self.decision
+    }
+
+    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision {
+        self.negotiatedCallCount += 1
+        self.negotiatedProtocols.append(context.protocolCodec)
+        return self.decision
+    }
+}
+
+/// A `StreamGater` that takes its time before accepting, so a test can observe what the connection
+/// does while a verdict is outstanding.
+actor SlowStreamGater: StreamGater {
+    private let delay: Duration
+    private(set) var hasAnswered = false
+
+    init(delay: Duration) {
+        self.delay = delay
+    }
+
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+        try? await Task.sleep(for: self.delay)
+        self.hasAnswered = true
+        return .accept
+    }
+}
+
+/// A `Muxer` that holds no streams and only records the channels it was asked to drop.
+///
+/// `MockMuxer` can't serve here: it only removes streams it minted itself, so it can't observe a
+/// `removeStream(channel:)` for a child channel the connection created.
+final class RecordingMuxer: Muxer, @unchecked Sendable {
+    static var protocolCodec: String { "/recording-mux/1.0.0" }
+
+    var onStream: ((_Stream) -> Void)?
+    var onStreamEnd: ((LibP2PCore.Stream) -> Void)?
+    var _connection: Connection?
+
+    private let eventLoop: EventLoop
+    private let removedChannels = NIOLockedValueBox<[ObjectIdentifier]>([])
+
+    /// How many channels this muxer was asked to drop.
+    var removedChannelCount: Int { self.removedChannels.withLockedValue { $0.count } }
+
+    func wasAskedToRemove(_ channel: Channel) -> Bool {
+        self.removedChannels.withLockedValue { $0.contains(ObjectIdentifier(channel)) }
+    }
+
+    init(eventLoop: EventLoop) {
+        self.eventLoop = eventLoop
+    }
+
+    var streams: [LibP2PCore.Stream] { [] }
+
+    func newStream(channel: Channel, proto: String) throws -> EventLoopFuture<_Stream> {
+        self.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
+
+    func openStream(_ stream: inout LibP2PCore.Stream) throws -> EventLoopFuture<Void> {
+        self.eventLoop.makeSucceededVoidFuture()
+    }
+
+    func getStream(id: UInt64, mode: Mode) -> EventLoopFuture<LibP2PCore.Stream?> {
+        self.eventLoop.makeSucceededFuture(nil)
+    }
+
+    func updateStream(channel: Channel, state: LibP2PCore.StreamState, proto: String) -> EventLoopFuture<Void> {
+        self.eventLoop.makeSucceededVoidFuture()
+    }
+
+    func removeStream(channel: Channel) {
+        self.removedChannels.withLockedValue { $0.append(ObjectIdentifier(channel)) }
+        channel.close(mode: .all, promise: nil)
+    }
+}

--- a/Tests/LibP2PTests/StreamPrunerTests.swift
+++ b/Tests/LibP2PTests/StreamPrunerTests.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import LibP2PCore
+import LibP2PTesting
 import NIOCore
 import Testing
 
@@ -59,7 +60,12 @@ extension LibP2PTests {
         @Test("Terminal streams are always evicted", arguments: [StreamState.closed, .reset])
         func testTerminalStreamsAreEvicted(state: StreamState) {
             let action = IdleTimeoutStreamPruner.action(
-                for: Self.snapshot(state: state, openedSecondsAgo: 0, negotiatedSecondsAgo: 0, lastActivitySecondsAgo: 0),
+                for: Self.snapshot(
+                    state: state,
+                    openedSecondsAgo: 0,
+                    negotiatedSecondsAgo: 0,
+                    lastActivitySecondsAgo: 0
+                ),
                 now: Self.now,
                 configuration: Self.config
             )
@@ -70,7 +76,10 @@ extension LibP2PTests {
         // MARK: - Half-closed streams
 
         /// One side closed, a half-closed stream may legitimately keep draining, but not forever.
-        @Test("Half-closed streams past the grace period are reset", arguments: [StreamState.receiveClosed, .writeClosed])
+        @Test(
+            "Half-closed streams past the grace period are reset",
+            arguments: [StreamState.receiveClosed, .writeClosed]
+        )
         func testStuckHalfClosedStreamsAreReset(state: StreamState) {
             let action = IdleTimeoutStreamPruner.action(
                 for: Self.snapshot(
@@ -86,7 +95,10 @@ extension LibP2PTests {
         }
 
         /// A half-closed stream that just moved bytes is still draining, leave it alone.
-        @Test("Half-closed streams inside the grace period are kept", arguments: [StreamState.receiveClosed, .writeClosed])
+        @Test(
+            "Half-closed streams inside the grace period are kept",
+            arguments: [StreamState.receiveClosed, .writeClosed]
+        )
         func testDrainingHalfClosedStreamsAreKept(state: StreamState) {
             let action = IdleTimeoutStreamPruner.action(
                 for: Self.snapshot(
@@ -244,6 +256,44 @@ extension LibP2PTests {
             #expect(config.negotiationTimeout < Application.Connections.defaultUpgradeTimeout)
             #expect(config.closingGrace < config.negotiationTimeout)
             #expect(config.negotiationTimeout < config.dataIdleTimeout)
+        }
+
+        /// A pruner that disables sweeping must not get a sweep task scheduled against it
+        @Test("A NoOp pruner leaves no sweep scheduled, an idle-timeout pruner arms one")
+        func testSweepIsScheduledOnlyWhenThePrunerWantsIt() async throws {
+            try await withApp { app in
+                let loop = EmbeddedEventLoop()
+
+                let quiet = BaseConnection(
+                    application: app,
+                    channel: EmbeddedChannel(loop: loop),
+                    direction: .outbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
+                    expectedRemotePeer: nil,
+                    streamGater: AllowAllStreamGater(),
+                    streamPruner: NoOpStreamPruner()
+                )
+                quiet.armPruneSweepForTesting()
+                #expect(quiet.hasPruneSweepScheduled == false)
+
+                let sweeping = BaseConnection(
+                    application: app,
+                    channel: EmbeddedChannel(loop: loop),
+                    direction: .outbound,
+                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1235"),
+                    expectedRemotePeer: nil,
+                    streamGater: AllowAllStreamGater(),
+                    streamPruner: IdleTimeoutStreamPruner()
+                )
+                sweeping.armPruneSweepForTesting()
+                #expect(sweeping.hasPruneSweepScheduled == true)
+
+                // Closing must take the sweep down with it, so nothing we scheduled outlives us.
+                let closed: EventLoopFuture<Void> = sweeping.close()
+                loop.run()
+                try await closed.get()
+                #expect(sweeping.hasPruneSweepScheduled == false)
+            }
         }
 
         // MARK: - Helpers

--- a/Tests/LibP2PTests/StreamPrunerTests.swift
+++ b/Tests/LibP2PTests/StreamPrunerTests.swift
@@ -1,0 +1,261 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LibP2PCore
+import NIOCore
+import Testing
+
+@testable import LibP2P
+
+extension LibP2PTests {
+
+    @Suite("StreamPrunerTests")
+    struct StreamPrunerTests {
+
+        /// A distinct key per snapshot.
+        final class Token: Sendable {}
+        static let tokens: [Token] = (0..<8).map { _ in Token() }
+
+        /// Fixed "now" so every case is deterministic; ages are expressed relative to it.
+        static let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        static func snapshot(
+            index: Int = 0,
+            state: StreamState,
+            protocolCodec: String = "/echo/1.0.0",
+            openedSecondsAgo: TimeInterval,
+            negotiatedSecondsAgo: TimeInterval? = nil,
+            lastActivitySecondsAgo: TimeInterval? = nil
+        ) -> StreamLivenessSnapshot {
+            StreamLivenessSnapshot(
+                key: ObjectIdentifier(tokens[index]),
+                id: UInt64(index),
+                direction: .inbound,
+                state: state,
+                protocolCodec: protocolCodec,
+                openedAt: now.addingTimeInterval(-openedSecondsAgo),
+                negotiatedAt: negotiatedSecondsAgo.map { now.addingTimeInterval(-$0) },
+                lastActivityAt: lastActivitySecondsAgo.map { now.addingTimeInterval(-$0) }
+            )
+        }
+
+        static let config = IdleTimeoutStreamPruner.Configuration()
+
+        // MARK: - Terminal streams
+
+        /// A stream the muxer hasn't cleared yet is still on our books; evict it so the two agree.
+        @Test("Terminal streams are always evicted", arguments: [StreamState.closed, .reset])
+        func testTerminalStreamsAreEvicted(state: StreamState) {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(state: state, openedSecondsAgo: 0, negotiatedSecondsAgo: 0, lastActivitySecondsAgo: 0),
+                now: Self.now,
+                configuration: Self.config
+            )
+            // Terminal regardless of how fresh the activity stamp is.
+            #expect(isClose(action))
+        }
+
+        // MARK: - Half-closed streams
+
+        /// One side closed, a half-closed stream may legitimately keep draining, but not forever.
+        @Test("Half-closed streams past the grace period are reset", arguments: [StreamState.receiveClosed, .writeClosed])
+        func testStuckHalfClosedStreamsAreReset(state: StreamState) {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(
+                    state: state,
+                    openedSecondsAgo: 30,
+                    negotiatedSecondsAgo: 29,
+                    lastActivitySecondsAgo: 5  // > closingGrace (3s)
+                ),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(isReset(action))
+        }
+
+        /// A half-closed stream that just moved bytes is still draining, leave it alone.
+        @Test("Half-closed streams inside the grace period are kept", arguments: [StreamState.receiveClosed, .writeClosed])
+        func testDrainingHalfClosedStreamsAreKept(state: StreamState) {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(
+                    state: state,
+                    openedSecondsAgo: 30,
+                    negotiatedSecondsAgo: 29,
+                    lastActivitySecondsAgo: 0.1  // < closingGrace (3s)
+                ),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(action == nil)
+        }
+
+        // MARK: - Streams that never negotiated
+
+        /// The remote opened a stream and never agreed on a protocol. Nothing is installed on its pipeline,
+        /// so there's no counterparty for a graceful close — reset it.
+        @Test("A stream that never negotiates is reset once the negotiation timeout lapses")
+        func testUnnegotiatedStreamIsReset() {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(
+                    state: .initialized,
+                    protocolCodec: "",
+                    openedSecondsAgo: 11  // > negotiationTimeout (10s)
+                ),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(isReset(action))
+        }
+
+        /// Still inside the window, negotiation may simply be in flight.
+        @Test("A stream still negotiating inside the window is kept")
+        func testNegotiatingStreamIsKept() {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(state: .initialized, protocolCodec: "", openedSecondsAgo: 2),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(action == nil)
+        }
+
+        // MARK: - Idle Streams
+
+        /// Negotiated, then silent past the data-idle window.
+        @Test("A negotiated stream that goes idle is closed")
+        func testIdleStreamIsClosed() {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(
+                    state: .open,
+                    openedSecondsAgo: 120,
+                    negotiatedSecondsAgo: 119,
+                    lastActivitySecondsAgo: 61  // > dataIdleTimeout (60s)
+                ),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(isClose(action))
+        }
+
+        /// A stream that negotiated but has never exchanged a byte is measured from negotiation, not
+        /// from `openedAt`, otherwise a slow negotiation would eat into its idle budget.
+        @Test("A stream with no activity is measured from when it negotiated")
+        func testNoActivityIsMeasuredFromNegotiation() {
+            // Opened long ago, negotiated recently, never exchanged data => keep.
+            let fresh = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(state: .open, openedSecondsAgo: 600, negotiatedSecondsAgo: 5),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(fresh == nil)
+
+            // Negotiated long ago, never exchanged data => close.
+            let stale = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(state: .open, openedSecondsAgo: 600, negotiatedSecondsAgo: 90),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(isClose(stale))
+        }
+
+        /// An active stream is kept
+        @Test("An actively used stream is kept")
+        func testActiveStreamIsKept() {
+            let action = IdleTimeoutStreamPruner.action(
+                for: Self.snapshot(
+                    state: .open,
+                    openedSecondsAgo: 3600,
+                    negotiatedSecondsAgo: 3599,
+                    lastActivitySecondsAgo: 0.5
+                ),
+                now: Self.now,
+                configuration: Self.config
+            )
+            #expect(action == nil)
+        }
+
+        // MARK: - The actor surface
+
+        /// `prune` is the API the connection actually calls: it must return only the streams to evict.
+        @Test("prune returns only the streams that should be evicted")
+        func testPruneReturnsOnlyEvictions() async {
+            let pruner = IdleTimeoutStreamPruner()
+            let healthy = Self.snapshot(
+                index: 0,
+                state: .open,
+                openedSecondsAgo: 100,
+                negotiatedSecondsAgo: 99,
+                lastActivitySecondsAgo: 1
+            )
+            let quiet = Self.snapshot(
+                index: 1,
+                state: .open,
+                openedSecondsAgo: 100,
+                negotiatedSecondsAgo: 99,
+                lastActivitySecondsAgo: 99
+            )
+            let never = Self.snapshot(index: 2, state: .initialized, protocolCodec: "", openedSecondsAgo: 30)
+
+            let actions = await pruner.prune([healthy, quiet, never], now: Self.now)
+
+            #expect(actions.count == 2)
+            #expect(actions[healthy.key] == nil)
+            #expect(isClose(actions[quiet.key]))
+            #expect(isReset(actions[never.key]))
+            #expect(await pruner.totalPruned == 2)
+        }
+
+        /// An empty connection produces no work.
+        @Test("prune on no streams evicts nothing")
+        func testPruneWithNoStreams() async {
+            let pruner = IdleTimeoutStreamPruner()
+            #expect(await pruner.prune([], now: Self.now).isEmpty)
+        }
+
+        /// `NoOpStreamPruner` must both refuse to be scheduled and evict nothing, it's what preserves
+        /// the legacy `ARCConnection` / `BasicConnectionLight` behaviour.
+        @Test("NoOpStreamPruner never prunes and never asks to be scheduled")
+        func testNoOpPruner() async {
+            let pruner = NoOpStreamPruner()
+            #expect(pruner.sweepInterval == nil)
+            let everything = [
+                Self.snapshot(index: 0, state: .closed, openedSecondsAgo: 10_000),
+                Self.snapshot(index: 1, state: .initialized, protocolCodec: "", openedSecondsAgo: 10_000),
+            ]
+            #expect(await pruner.prune(everything, now: Self.now).isEmpty)
+        }
+
+        /// The default configuration must stay inside the connection manager's upgrade window, or a
+        /// connection could be closed for failing to upgrade before its streams were ever pruned.
+        @Test("Default negotiation timeout stays inside the connection upgrade timeout")
+        func testDefaultsAreConsistentWithConnectionTimeouts() {
+            let config = IdleTimeoutStreamPruner.Configuration()
+            #expect(config.negotiationTimeout < Application.Connections.defaultUpgradeTimeout)
+            #expect(config.closingGrace < config.negotiationTimeout)
+            #expect(config.negotiationTimeout < config.dataIdleTimeout)
+        }
+
+        // MARK: - Helpers
+
+        private func isClose(_ action: StreamPruneAction?) -> Bool {
+            if case .close = action { return true }
+            return false
+        }
+
+        private func isReset(_ action: StreamPruneAction?) -> Bool {
+            if case .reset = action { return true }
+            return false
+        }
+    }
+}

--- a/Tests/LibP2PTests/TransportConformanceHarnessTests.swift
+++ b/Tests/LibP2PTests/TransportConformanceHarnessTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LibP2P
 import Testing
 
 @testable import LibP2PTesting
@@ -21,15 +22,27 @@ extension LibP2PTests.ConformanceHarnessTests {
     @Suite("TransportConformanceHarness")
     struct TransportConformanceHarnessTests {
 
+        static let connectionTypes: [AppConnection.Type] = [
+            ARCConnection.self,
+            BasicConnectionLight.self,
+            BaseConnection.self,
+        ]
+
         /// Self-tests the `TransportConformanceHarness` end-to-end against the built-in TCP transport, paired with
         /// the in-package plaintext security + wire muxer. Exercises the whole harness (dial, byte movement, upgrade,
         /// PeerID exchange, events, teardown) using only in-package code.
-        @Test("Built-in TCP transport passes transport conformance end-to-end")
-        func tcpPassesConformance() async throws {
+        @Test(
+            "Built-in TCP transport passes transport conformance end-to-end",
+            arguments: TransportConformanceHarnessTests.connectionTypes
+        )
+        func tcpPassesConformance(_ connectionType: AppConnection.Type) async throws {
             // TCP's dial side is auto-registered on the Application; we only need to add its listener.
             let report = try await runTransportConformance(
                 transportKey: "tcp",
-                configure: { $0.servers.use(.tcp(host: "127.0.0.1", port: 0)) }
+                configure: {
+                    $0.servers.use(.tcp(host: "127.0.0.1", port: 0))
+                    $0.connectionManager.use(connectionType: connectionType)
+                }
             )
             #expect(report.passed, "\(report)")
         }


### PR DESCRIPTION
### What?
This PR introduces `BaseConnection`, a merger / rewrite of `BasicConnectionLight` and `ARCConnection`

### Changes:
- Introduces the following protocols
    - `StreamGater`:  A way for users to define which streams are allowed / denied.
    - `StreamPruner`:  A way for users to define which streams are pruned and at what rate
- `BaseConnection` relies on the installed `StreamGater` and `StreamPruner` to handle the complexities of stream pruning and gating. It also allows users to define their own logic without implementing an entire `AppConnection`.

```swift
// StreamGater Protocol
protocol StreamGater: Sendable {
    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision
    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision
}

// StreamPruner Protocol
protocol StreamPruner: Sendable {
    var sweepInterval: TimeAmount? { get }
    func prune(_ streams: [StreamLivenessSnapshot], now: Date) async -> [ObjectIdentifier: StreamPruneAction]
}

// Install them with
app.connectionManager.use(streamGater:)
app.connectionManager.use(streamPruner:)
```

- We also introduced a `StreamActivityRecord` that provides us a way to track a `Stream` last activity (bytes entering / exiting the `Response` handler)
- And a bunch of new tests (mostly generated by opus)

> [!NOTE]
> The default AppConnection has been switched from `ARCConnection` to `BaseConnection`