### PR TITLE
StreamGater Change and Base Connection Work

### DIFF
--- a/Sources/LibP2P/Connections/BaseConnection.swift
+++ b/Sources/LibP2P/Connections/BaseConnection.swift
@@ -30,57 +30,63 @@ import Logging
 ///  app.connectionManager.use(streamPruner: )
 ///  ```
 public final class BaseConnection: AppConnection, @unchecked Sendable {
-
+    
     public let application: Application
-
+    
     public let channel: Channel
     private var eventLoop: EventLoop {
         self.channel.eventLoop
     }
-
+    
     public let id: UUID
-
+    
     public var localAddr: Multiaddr?
-
+    
     public var remoteAddr: Multiaddr?
-
+    
     public let localPeer: PeerID
-
-    public var remotePeer: PeerID?
-
+    
+    /// The authenticated remote peer.
+    ///
+    /// Owned by ``stateMachine`` — `nil` until the security handshake completes, non-nil for the rest of
+    /// the connection's life (a handshake that produces no peer closes the connection).
+    public var remotePeer: PeerID? {
+        self.stateMachine.remotePeer
+    }
+    
     public var expectedRemotePeer: PeerID?
-
+    
     public let stats: ConnectionStats
-
+    
     public var tags: Any? = nil
-
+    
     public private(set) var registry: [UInt64: LibP2PCore.Stream] = [:]
-
+    
     public var streams: [LibP2PCore.Stream] {
         self.muxer?.streams ?? []
     }
-
+    
     public weak var muxer: Muxer? = nil
-
+    
     public var isMuxed: Bool = false
-
+    
     public var status: ConnectionStats.Status {
         self.stats.status
     }
-
+    
     public var timeline: [ConnectionStats.Status: Date] {
         self.stats.timeline.history
     }
-
+    
     /// Our Connection's Logger
     public var logger: Logger
-
+    
     /// Decides which streams we're willing to carry.
     private let streamGater: StreamGater
-
+    
     /// Decides which of our streams get evicted.
     private let streamPruner: StreamPruner
-
+    
     struct StreamStateEntry {
         let proto: String
         let direction: ConnectionStats.Direction
@@ -90,22 +96,24 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     /// Keep track of our Streams and thier lifecycle history.
     /// Feeds `lastActivity()`, which our ConnectionManager reads.
     internal private(set) var streamHistory: [StreamStateEntry] = []
-
+    
     private var stateMachine: ConnectionStateMachine
     public var state: ConnectionState {
         self.stateMachine.state
     }
-
+    
     /// These promises are used only once while upgrading the parent channel
     private let securedPromise: EventLoopPromise<SecuredResult>
     private let muxedPromise: EventLoopPromise<Muxer>
-
+    
+    /// Whether each upgrade promise has been completed, so `deinit` can settle whatever is left
+    private var securedPromiseSettled: Bool = false
+    private var muxedPromiseSettled: Bool = false
+    
     /// The timestamp at which this connection was instantiated
     private let startTime: UInt64
-
-    // MARK: - Idle connection teardown
-
-    /// The IdleTimeout Task that gets set each time our connection gets to zero (0) open streams.
+    
+    /// The IdleTimeout Task that gets set each time our connection gets to zero open streams.
     /// We wait `idleTimeoutMilliseconds` for a new Stream to be opened. If one isn't opened in that
     /// window, the connection shuts down and deinits itself.
     ///
@@ -113,9 +121,11 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     private var idleTimeoutTask: Scheduled<Void>? = nil
     /// The time in milliseconds that our connection will sit idle before terminating itself.
     private var idleTimeoutMilliseconds: Int64 = 250
-
-    // MARK: - Stream pruning
-
+    
+    /// Pending / Unopened Stream Caches
+    private var newStreamCache: [StreamCache] = []
+    private var pendingStreamCache: [StreamCache] = []
+    
     /// What we track per muxed stream so `streamPruner` can reason about liveness.
     ///
     /// Keyed by `ObjectIdentifier(childChannel)` rather than by stream `id`, because some muxer
@@ -125,18 +135,16 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
         let direction: ConnectionStats.Direction
         let openedAt: Date
         let activity: StreamActivityRecord
-        /// The pre-negotiation gater verdict: succeeds on accept, fails on reject.
-        let inboundGate: EventLoopFuture<Void>
         /// Resolved once the stream has negotiated a protocol; `nil` while it's still upgrading.
         var stream: LibP2PCore.Stream?
         var negotiatedAt: Date?
     }
     private var streamRecords: [ObjectIdentifier: StreamRecord] = [:]
-
+    
     /// The repeating sweep that asks our `streamPruner` what to evict.
     /// Started once we're muxed and cancelled on teardown.
     private var pruneSweepTask: RepeatedTask? = nil
-
+    
     public convenience init(
         application: Application,
         channel: Channel,
@@ -154,7 +162,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             streamPruner: application.connectionManager.streamPruner
         )
     }
-
+    
     /// Designated initializer, taking the gater and pruner explicitly.
     ///
     /// - Note: Designed to be used in Tests so we can explicitly install Gaters and Pruners
@@ -178,48 +186,47 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
         self.stateMachine = ConnectionStateMachine()
         self.streamGater = streamGater
         self.streamPruner = streamPruner
-
+        
         // Addresses
         self.localAddr = try? channel.localAddress?.toMultiaddr()
         self.remoteAddr = remoteAddress
-
+        
         // Peers
         self.localPeer = application.peerID
-        self.remotePeer = nil
         self.expectedRemotePeer = expectedRemotePeer
-
-        /// Metadata
+        
+        // Metadata
         self.registry = [:]
         self.tags = nil
         self.stats = ConnectionStats(uuid: id, direction: direction)
-
-        /// State Promises
+        
+        // State Promises
         self.securedPromise = channel.eventLoop.makePromise(of: SecuredResult.self)
         self.muxedPromise = channel.eventLoop.makePromise(of: Muxer.self)
-
+        
         self.startTime = DispatchTime.now().uptimeNanoseconds
-
-        /// Register our channel's close future
+        
+        // Register our channel's close future
         self.channel.closeFuture.whenComplete { [weak self] _ in
             guard let self = self else { return }
             self.logger.trace("Channel -> CloseFuture")
             self.stats.status = .closed
-
-            /// Teardown any tasks we've started
+            
+            // Teardown any tasks we've started
             self.cancelPruneSweep()
             self.cancelTimeoutTask()
-
-            /// Fail any streams that were queued while we were still upgrading. If the channel closed
-            /// before we finished muxing, those streams will never open. Surface the failure to their
-            /// callers immediately (this is what fails coalesced cold dials when an upgrade fails)
-            /// rather than leaving each request to hit its own timeout.
+            
+            // Fail any streams that were queued while we were still upgrading. If the channel closed
+            // before we finished muxing, those streams will never open. Surface the failure to their
+            // callers immediately (this is what fails coalesced cold dials when an upgrade fails)
+            // rather than leaving each request to hit its own timeout.
             self.failQueuedStreams(Application.Connections.Errors.connectionUpgradeFailed)
-
-            /// Should ensure that we actually connected before posting a disconnect event
+            
+            // Should ensure that we actually connected before posting a disconnect event
             if self.application.isRunning {
                 self.application.events.post(.disconnected(self, self.remotePeer))
             }
-
+            
             self.muxer?.onStream = nil
             self.muxer?.onStreamEnd = nil
             self.muxer?._connection = nil
@@ -227,52 +234,53 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             self.registry = [:]
             self.streamRecords = [:]
         }
-
+        
         self.logger.trace("Initialized")
     }
-
+    
     deinit {
-        /// We had a leaking promise get triggered here... When our connection deinitializes before the
-        /// securedPromise / muxedPromise are completed...
-        switch self.state {
-        case .raw:
+        // Settle any upgrade promise the connection died still holding — an unfulfilled one is a
+        // `fatalError` in debug builds.
+        if !self.securedPromiseSettled {
             self.securedPromise.fail(Application.Connections.Errors.timedOut)
+        }
+        if !self.muxedPromiseSettled {
             self.muxedPromise.fail(Application.Connections.Errors.timedOut)
-        case .secured:
-            self.muxedPromise.fail(Application.Connections.Errors.timedOut)
-        default:
-            break
         }
         self.cancelTimeoutTask()
         self.cancelPruneSweep()
         self.logger.trace("Deinitialized")
     }
+}
 
+// MARK: - Connection Upgrade
+
+extension BaseConnection {
     /// This method is called immediately after a new Connection is instantiated with a channel.
     /// It's sole priority is to register our sec and muxer callbacks and kick off the security upgrade.
     public func initializeChannel() -> EventLoopFuture<Void> {
-        /// Add our future result handlers to our Connection's state change promises
+        // Add our future result handlers to our Connection's state change promises
         self.securedPromise.futureResult.whenComplete { [weak self] result in
             guard let self = self else { return }
+            self.securedPromiseSettled = true
             self.onSecured(result)
         }
-
+        
         self.muxedPromise.futureResult.whenComplete { [weak self] result in
             guard let self = self else { return }
+            self.muxedPromiseSettled = true
             self.onMuxed(result)
         }
-
+        
         self.stats.status = .opening
-
-        /// Kickoff security upgrade (also responsible for negotiation)
+        
+        // Kickoff security upgrade (also responsible for negotiation)
         return self.secureConnection(promise: self.securedPromise).always { [weak self] _ in
             guard let self = self else { return }
             self.stats.status = .open
         }
     }
-
-    // MARK: - Upgrade
-
+    
     private func onSecured(_ result: Result<SecuredResult, Error>) {
         switch result {
         case .failure(let error):
@@ -284,19 +292,24 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
                 self.logger.info(
                     "Secured with `\(security.securityCodec)`! RemotePeer: \(String(describing: security.remotePeer)), Warnings: \(String(describing: security.warning))"
                 )
-                self.remotePeer = security.remotePeer
-                self.logger.info("Remote Address: \(self.remoteAddr?.description ?? "NIL")")
-                try self.stateMachine.secureConnection()
-                self.stats.encryption = security.securityCodec
-
-                if let rPeer = self.remotePeer {
-                    let pInfo = PeerInfo(peer: rPeer, addresses: [])
-                    self.application.events.post(.remotePeer(pInfo))
-                } else {
-                    self.logger.warning("Post Security handshake without knowledge of RemotePeer and/or RemoteAddress")
+                
+                // A connection isn't considered secured unless we know who we're talking to
+                guard let remotePeer = security.remotePeer else {
+                    self.logger.error(
+                        "Secured with `\(security.securityCodec)` but the handshake yielded no remote peer; closing"
+                    )
+                    self.channel.close(mode: .all, promise: nil)
+                    return
                 }
-
-                /// Kick off Muxer upgrade
+                
+                self.logger.info("Remote Address: \(self.remoteAddr?.description ?? "NIL")")
+                try self.stateMachine.secureConnection(remotePeer: remotePeer)
+                self.stats.encryption = security.securityCodec
+                
+                let pInfo = PeerInfo(peer: remotePeer, addresses: [])
+                self.application.events.post(.remotePeer(pInfo))
+                
+                // Kick off Muxer upgrade
                 self.muxConnection(promise: self.muxedPromise).whenComplete { res in
                     switch res {
                     case .failure(let error):
@@ -314,7 +327,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             }
         }
     }
-
+    
     private func onMuxed(_ result: Result<Muxer, Error>) {
         switch result {
         case .failure(let error):
@@ -329,48 +342,32 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
                 try self.stateMachine.muxConnection()
                 self.stats.status = .upgraded
                 self.stats.muxer = muxer.protocolCodec
-
-                /// Callbacks driving idle connection teardown
+                
+                // Callbacks driving idle connection teardown
                 self.muxer?.onStream = self.onNewStream
                 self.muxer?.onStreamEnd = self.onStreamClosed
-
+                
                 let timeToUpgrade = DispatchTime.now().uptimeNanoseconds - self.startTime
                 self.logger.notice("Upgrade Time: \(timeToUpgrade / 1_000_000) ms")
-
+                
                 self.eventLoop.execute {
-                    /// Our connection is upgraded...
+                    // Our connection is upgraded...
                     self.logger.trace("Our connection has been Secured and Muxed! We're ready to rock!")
                     self.application.events.post(.connected(self))
                     self.application.events.post(.upgraded(self))
-
-                    /// Now that streams are possible, start sweeping for dead ones.
+                    
+                    // Now that streams are possible, start sweeping for dead ones.
                     self.armPruneSweep()
-
-                    /// Open any pending streams now that we're muxed
-                    ///
-                    /// TODO: Not sure about this error handling....
-                    for pendingStream in self.pendingStreamCache {
-                        self.logger.debug(
-                            "Asking Muxer to open / initialize pending stream for protocol `\(pendingStream.proto)`"
-                        )
-                        self.newStreamCache.append(pendingStream)
-                        do {
-                            try muxer.newStream(channel: self.channel, proto: pendingStream.proto).whenComplete {
-                                result in
-                                switch result {
-                                case .success:
-                                    break
-                                case .failure(let error):
-                                    self.fail(pendingStream, with: error)
-                                }
-                            }
-                        } catch {
-                            self.fail(pendingStream, with: error)
-                        }
-                    }
+                    
+                    // Open any pending streams now that we're muxed.
+                    // These go through the same gated path as a stream requested after the upgrade
+                    let pending = self.pendingStreamCache
                     self.pendingStreamCache = []
+                    for pendingStream in pending {
+                        self.openStream(pendingStream)
+                    }
                 }
-
+                
             } catch {
                 self.logger.error("Failed to mux channel: \(error)")
                 self.channel.close(mode: .all, promise: nil)
@@ -378,598 +375,12 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             }
         }
     }
+}
 
-    // MARK: - Idle connection teardown
+// MARK: - Stream Opening
 
-    /// Called by our Muxer when a stream of ours has been closed.
-    /// - Note: We take this opportunity to check if there are any active streams and kick off our
-    ///   idleTimeoutTask if there aren't.
-    private func onStreamClosed(_ stream: LibP2PCore.Stream) {
-        self.logger.trace("On Stream Closed...")
-        guard let mux = self.muxer else {
-            self.logger.trace("No Muxer Available")
-            return
-        }
-        if mux.streams.isEmpty {
-            self.logger.trace("No Streams")
-            if self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty {
-                self.logger.trace("No Pending Streams")
-                self.armTimeoutTask()
-            }
-        } else {
-            self.logger.trace("We still have \(mux.streams.count) streams")
-            self.logger.trace(
-                "\(mux.streams.map { "Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)][\($0.streamState)]" }.joined(separator: "\n") )"
-            )
-        }
-    }
-
-    /// Called by our Muxer when a new stream has been opened
-    /// - Note: We take this opportunity to cancel the idleTimeoutTask if one exists.
-    private func onNewStream(_ stream: LibP2PCore.Stream) {
-        self.eventLoop.execute {
-            self.cancelTimeoutTask()
-            self.logger.trace("Notified of new stream, canceling existing idleTimeoutTask")
-        }
-    }
-
-    private func cancelTimeoutTask() {
-        self.idleTimeoutTask?.cancel()
-        self.idleTimeoutTask = nil
-    }
-
-    private func armTimeoutTask() {
-        guard self.idleTimeoutTask == nil else { return }
-        self.idleTimeoutTask = self.eventLoop.scheduleTask(in: .milliseconds(self.idleTimeoutMilliseconds)) {
-            /// Close ourselves and notify our connection manager
-            guard self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty else {
-                self.idleTimeoutTask = nil
-                return
-            }
-            self.logger.debug("Idle timeout reached. Terminating self")
-            let _ = self.close()
-        }
-    }
-
-    // MARK: - Stream gating
-
-    /// Bridges the (actor-isolated) gater's verdict back onto `childChannel`'s event loop.
-    ///
-    /// The returned future succeeds on `.accept` and fails on `.reject`, so callers can simply chain
-    /// their pipeline configuration off it.
-    private func gate(
-        _ decide: @escaping @Sendable () async -> StreamGateDecision,
-        on childChannel: Channel,
-        describing what: String
-    ) -> EventLoopFuture<Void> {
-        let promise = childChannel.eventLoop.makePromise(of: Void.self)
-        let logger = self.logger
-        let eventLoop = childChannel.eventLoop
-        Task {
-            let decision = await decide()
-            eventLoop.execute {
-                switch decision {
-                case .accept:
-                    promise.succeed(())
-                case .reject(let reason):
-                    logger.notice("StreamGater rejected \(what): \(reason)")
-                    promise.fail(Errors.streamRejectedByGater(reason: reason))
-                }
-            }
-        }
-        return promise.futureResult
-    }
-
-    /// Asks the gater about a stream whose protocol has just been agreed.
-    private func gateNegotiatedStream(
-        protocol proto: String,
-        direction: ConnectionStats.Direction,
-        on childChannel: Channel
-    ) -> EventLoopFuture<Void> {
-        let context = NegotiatedStreamGateContext(
-            connectionID: self.id,
-            remotePeer: self.remotePeer,
-            remoteAddress: self.remoteAddr,
-            direction: direction,
-            protocolCodec: proto,
-            openStreamCount: self.muxer?.streams.count ?? 0
-        )
-        let gater = self.streamGater
-        return self.gate(
-            { await gater.shouldAcceptNegotiatedStream(context) },
-            on: childChannel,
-            describing: "\(direction) `\(proto)` stream"
-        )
-    }
-
-    // MARK: - Child channels
-
-    /// This function gets called by our Muxer when instantiating a new inbound child Channel.
-    /// Take this opportunity to configure the child channel's pipeline before data transmission begins.
-    ///
-    /// - Important: The future we return is what gates the child channel's *activation*, and it must
-    ///   complete within this event-loop tick. Muxers differ sharply here: `mplex` buffers inbound
-    ///   frames in `pendingReads` until activation, but YAMUX's child-channel state machine treats any
-    ///   frame arriving while the stream is still `.requestedRemotely` as a protocol violation
-    ///   (`YAMUX.Error.protocolViolation`) — it only sends the open-confirmation once this future
-    ///   resolves. A peer that pipelines its payload behind the stream-open therefore breaks the stream
-    ///   if we suspend here. So the multistream-select upgrader is installed *synchronously* and the
-    ///   gater is consulted concurrently; see ``StreamGater/shouldAcceptInboundStream(_:)`` for what
-    ///   that means for the guarantee.
-    public func inboundMuxedChildChannelInitializer(_ childChannel: Channel) -> EventLoopFuture<Void> {
-        // Cancel our idleTimeoutTask if we have one
-        self.cancelTimeoutTask()
-
-        let context = InboundStreamGateContext(
-            connectionID: self.id,
-            remotePeer: self.remotePeer,
-            remoteAddress: self.remoteAddr,
-            openStreamCount: self.muxer?.streams.count ?? 0
-        )
-        let gater = self.streamGater
-        let gate = self.gate(
-            { await gater.shouldAcceptInboundStream(context) },
-            on: childChannel,
-            describing: "inbound stream"
-        )
-
-        // Start tracking the stream for pruning purposes right away — a stream that never negotiates
-        // is exactly the sort of thing the pruner exists to reap. The gate future rides along so the
-        // negotiation path can re-check it before installing any route handlers.
-        self.trackStream(on: childChannel, direction: .inbound, inboundGate: gate)
-
-        // Tear a rejected stream down as soon as the gater answers, rather than waiting for it to
-        // negotiate a protocol it will never be allowed to use.
-        gate.whenFailure { [weak self] _ in
-            guard let self = self else { return }
-            self.untrackStream(on: childChannel)
-            self.muxer?.removeStream(channel: childChannel)
-        }
-
-        return self.configureInboundUpgrader(on: childChannel)
-    }
-
-    /// Installs the multistream-select listener on an accepted inbound child channel.
-    private func configureInboundUpgrader(on childChannel: Channel) -> EventLoopFuture<Void> {
-        let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
-
-        let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
-            protocols: self.application.routes.all.map { $0.description },
-            mode: .listener,
-            logger: self.logger,
-            promise: negotiationPromise
-        )
-
-        negotiationPromise.futureResult.whenComplete { [weak self] result in
-            guard let self = self, self.application.isRunning else { return }
-            switch result {
-            case .failure(let error):
-                self.untrackStream(on: childChannel)
-                self.muxer?.removeStream(channel: childChannel)
-                self.logger.error("Error while upgrading Inbound ChildChannel: \(error)")
-
-            case .success(let proto):
-                /// Append a stream event in our stream history array
-                self.streamHistory.append(
-                    StreamStateEntry(
-                        proto: proto.protocol.description,
-                        direction: .inbound,
-                        state: .initialized,
-                        date: Date()
-                    )
-                )
-
-                /// Re-check the pre-negotiation verdict before doing anything else. It was consulted
-                /// concurrently with installing the upgrader (see the note on
-                /// ``inboundMuxedChildChannelInitializer(_:)``), so a slow gater may not have answered
-                /// yet — but by now the mss upgrader is buffering inbound bytes and nothing has reached a
-                /// route handler, so waiting here is safe and no stream slips past a rejection.
-                self.inboundGate(for: childChannel)
-                    .flatMap {
-                        self.gateNegotiatedStream(protocol: proto.protocol, direction: .inbound, on: childChannel)
-                    }
-                    .whenComplete { gateResult in
-                        switch gateResult {
-                        case .failure:
-                            self.untrackStream(on: childChannel)
-                            self.muxer?.removeStream(channel: childChannel)
-                        case .success:
-                            self.finishUpgrading(
-                                proto,
-                                childChannel: childChannel,
-                                responder: self.application.responder.current,
-                                direction: .inbound
-                            )
-                        }
-                    }
-            }
-        }
-        return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
-    }
-
-    /// This function gets called by our Muxer when instantiating a new outbound child Channel.
-    /// Take this opportunity to configure the child channel's pipeline for the specified protocol
-    /// before data transmission begins.
-    public func outboundMuxedChildChannelInitializer(_ childChannel: Channel, protocol: String) -> EventLoopFuture<Void>
-    {
-        self.eventLoop.flatSubmit {
-            // Cancel our idleTimeoutTask if we have one
-            self.cancelTimeoutTask()
-
-            guard let idx = self.newStreamCache.firstIndex(where: { $0.proto == `protocol` }) else {
-                self.logger.error("No Responder For `\(`protocol`)`")
-                self.logger.error("\(self.newStreamCache)")
-                return childChannel.eventLoop.makeFailedFuture(Application.Connections.Errors.noResponder)
-            }
-            let pendingStream = self.newStreamCache.remove(at: idx)
-
-            /// We initiated this stream, so there's no pre-negotiation gate to run — only the
-            /// post-negotiation one below.
-            self.trackStream(on: childChannel, direction: .outbound)
-
-            let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
-            let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
-                protocols: [`protocol`],
-                mode: .initiator,
-                logger: self.logger,
-                promise: negotiationPromise
-            )
-
-            negotiationPromise.futureResult.whenComplete { [weak self] result in
-                guard let self = self, self.application.isRunning else { return }
-                switch result {
-                case .failure(let error):
-                    self.untrackStream(on: childChannel)
-                    self.muxer?.removeStream(channel: childChannel)
-                    self.logger.error("Error while upgrading Outbound ChildChannel: \(error)")
-
-                case .success(let proto):
-                    /// Append a stream event in our stream history array
-                    self.streamHistory.append(
-                        StreamStateEntry(
-                            proto: proto.protocol.description,
-                            direction: .outbound,
-                            state: .initialized,
-                            date: Date()
-                        )
-                    )
-
-                    self.gateNegotiatedStream(protocol: proto.protocol, direction: .outbound, on: childChannel)
-                        .whenComplete { gateResult in
-                            switch gateResult {
-                            case .failure(let error):
-                                self.untrackStream(on: childChannel)
-                                self.muxer?.removeStream(channel: childChannel)
-                                /// Our own caller is waiting on this stream — tell them why it died.
-                                self.fail(pendingStream, with: error)
-                            case .success:
-                                self.finishUpgrading(
-                                    proto,
-                                    childChannel: childChannel,
-                                    responder: pendingStream.responder,
-                                    direction: .outbound
-                                )
-                            }
-                        }
-                }
-            }
-            return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
-        }
-    }
-
-    /// Shared tail of the inbound and outbound upgrade paths: install the route's handlers, record the
-    /// stream, and announce it.
-    ///
-    /// - Important: Unlike in `ARCConnection`, this does **not** run in the same event-loop tick as
-    ///   protocol negotiation — the ``StreamGater`` consultation in between hops through an actor. The
-    ///   stream can therefore be gone by the time we get here: a route answering `.respondThenClose`
-    ///   over an in-process muxer closes it within that window essentially every time. Configuring a
-    ///   dead stream's pipeline is meaningless everywhere, and outright fatal on muxers whose stream
-    ///   channel releases its `ChannelPipeline` on close, so bail out first.
-    private func finishUpgrading(
-        _ proto: NegotiationResult,
-        childChannel: Channel,
-        responder: Responder,
-        direction: ConnectionStats.Direction
-    ) {
-        guard childChannel.isActive else {
-            self.logger.debug(
-                "`\(proto.protocol)` stream closed while it was being gated; skipping pipeline configuration"
-            )
-            self.untrackStream(on: childChannel)
-            return
-        }
-
-        self.upgradeChildChannel(
-            proto,
-            childChannel: childChannel,
-            responder: responder,
-            direction: direction
-        ).whenComplete { [weak self] result in
-            guard let self = self, self.application.isRunning else { return }
-
-            /// Append a stream event in our stream history array
-            self.streamHistory.append(
-                StreamStateEntry(proto: proto.protocol, direction: direction, state: .open, date: Date())
-            )
-
-            self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
-            self.logger.debug("🔀 New \(direction) ChildChannel[`\(proto)`] Ready!")
-            self.logger.trace("List of Streams:")
-            self.logger.trace(
-                "\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))"
-            )
-
-            // Post about the new stream on our application's Event Bus
-            guard case .success = result else { return }
-            guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
-            str._connection.withLockedValue { $0 = self }
-            /// Now that the muxer has a fully formed Stream for this channel, hand it to the pruner's
-            /// bookkeeping so eviction can go through the Stream API rather than the raw channel.
-            self.resolveTrackedStream(str, on: childChannel)
-            self.application.events.post(.openedStream(str))
-            childChannel.closeFuture.whenComplete { [weak self] _ in
-                guard let self = self else { return }
-                /// Append a stream event in our stream history array
-                self.streamHistory.append(
-                    StreamStateEntry(proto: proto.protocol, direction: direction, state: .closed, date: Date())
-                )
-                self.application.events.post(.closedStream(str))
-            }
-        }
-    }
-
-    /// To be called when the childChannel's protocol negotiation completes
-    ///
-    /// Note: Also is responsible for forwarding any leftover bytes received during the childChannel
-    /// upgrade process
-    private func upgradeChildChannel(
-        _ proto: NegotiationResult,
-        childChannel: Channel,
-        responder: Responder,
-        direction: ConnectionStats.Direction
-    ) -> EventLoopFuture<Void> {
-        //Install the protocol on the channel's pipeline...
-        logger.trace("Negotiated \(proto)")
-
-        /// `muxer` is held weakly, and the gate hop before us means the connection may have torn down
-        /// since negotiation completed.
-        guard let muxer = self.muxer else {
-            logger.debug("Muxer went away before `\(proto.protocol)` could be installed")
-            return childChannel.eventLoop.makeFailedFuture(
-                Application.Connections.Errors.connectionUpgradeFailed
-            )
-        }
-        guard var handlers = responder.pipelineConfig(for: proto.protocol, on: self) else {
-            /// Unhandled protocol negotiated
-            logger.trace("Unhandled protocol negotiated `\(proto.protocol)`")
-            return childChannel.eventLoop.makeSucceededVoidFuture()
-        }
-        logger.trace("Attempting to install route (`\(proto)`) specific ChannelHandlers")
-        logger.trace("\(handlers.map({ String(describing: $0) }).joined(separator: ", "))")
-
-        /// Prepare our activity monitor for the Encoder / Decoder handlers
-        let activity = self.activityRecord(for: childChannel)
-
-        handlers.append(
-            contentsOf: [
-                RequestEncoderChannelHandler(
-                    application: application,
-                    connection: self,
-                    protocol: proto.protocol,
-                    logger: logger,
-                    direction: direction,
-                    activity: activity
-                ),
-                ResponseDecoderChannelHandler(logger: logger, activity: activity),
-                ResponderChannelHandler(responder: responder, logger: logger),
-            ] as [ChannelHandler]
-        )
-
-        let codec = proto.protocol
-
-        /// Every step below is separated from the next by at least one event-loop tick (`updateStream`
-        /// hops through the muxer's loop; each `flatMap` can span ticks), so the stream may close
-        /// on us mid-operation.
-        ///
-        /// Configuring a dead stream's pipeline is meaningless, so each step checks first. And a porely
-        /// implemented muxer that destroys it's pipeline on close / teardown, could cause us to trap here,
-        /// so we check before proceeding
-        return muxer.updateStream(channel: childChannel, state: .open, proto: codec).flatMap {
-            () -> EventLoopFuture<Void> in
-            guard self.streamIsStillOpen(childChannel, proto: codec) else {
-                return childChannel.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
-            }
-            return childChannel.pipeline.addHandlers(handlers, position: .last)
-        }.flatMap { () -> EventLoopFuture<Void> in
-            guard self.streamIsStillOpen(childChannel, proto: codec) else {
-                return childChannel.eventLoop.makeFailedFuture(ChannelError.ioOnClosedChannel)
-            }
-            return childChannel.pipeline.removeHandler(name: "upgrader")
-        }.flatMap { () -> EventLoopFuture<Void> in
-            guard let lo = proto.leftoverBytes, lo.readableBytes > 0 else {
-                return childChannel.eventLoop.makeSucceededVoidFuture()
-            }
-            guard self.streamIsStillOpen(childChannel, proto: codec), childChannel.isWritable else {
-                self.logger.error("Failed to forward leftover bytes along pipeline")
-                return childChannel.eventLoop.makeSucceededVoidFuture()
-            }
-            self.logger.trace("Forwarding leftover bytes along pipeline...")
-            childChannel.pipeline.fireChannelRead(NIOAny(proto.leftoverBytes))
-            return childChannel.eventLoop.makeSucceededVoidFuture()
-        }
-    }
-
-    /// Whether it's still worth touching `childChannel.pipeline`.
-    private func streamIsStillOpen(_ childChannel: Channel, proto: String) -> Bool {
-        guard childChannel.isActive else {
-            self.logger.debug("`\(proto)` stream closed mid-upgrade; abandoning its pipeline")
-            return false
-        }
-        return true
-    }
-
-    // MARK: - Stream pruning
-
-    /// Begin tracking a child channel. Called the moment we learn of a stream, negotiated or not.
-    /// - Note: Must be called on `self.eventLoop`.
-    private func trackStream(
-        on childChannel: Channel,
-        direction: ConnectionStats.Direction,
-        inboundGate: EventLoopFuture<Void>? = nil
-    ) {
-        let key = ObjectIdentifier(childChannel)
-        guard self.streamRecords[key] == nil else { return }
-        self.streamRecords[key] = StreamRecord(
-            channel: childChannel,
-            direction: direction,
-            openedAt: Date(),
-            activity: StreamActivityRecord(),
-            inboundGate: inboundGate ?? childChannel.eventLoop.makeSucceededVoidFuture(),
-            stream: nil,
-            negotiatedAt: nil
-        )
-        /// Drop the record whenever the channel goes away, whatever closed it. Registered here rather
-        /// than on the successful-upgrade path so streams that never negotiate get cleaned up too.
-        childChannel.closeFuture.whenComplete { [weak self] _ in
-            self?.streamRecords.removeValue(forKey: key)
-        }
-    }
-
-    /// - Note: Must be called on `self.eventLoop`.
-    private func untrackStream(on childChannel: Channel) {
-        self.streamRecords.removeValue(forKey: ObjectIdentifier(childChannel))
-    }
-
-    /// - Note: Must be called on `self.eventLoop`.
-    private func activityRecord(for childChannel: Channel) -> StreamActivityRecord? {
-        self.streamRecords[ObjectIdentifier(childChannel)]?.activity
-    }
-
-    /// The pre-negotiation gate verdict for a stream.
-    ///
-    /// A missing record means the stream was already torn down (a rejection that landed before
-    /// negotiation completed clears it), so treat that as a rejection too rather than letting the
-    /// stream through on a technicality.
-    /// - Note: Must be called on `self.eventLoop`.
-    private func inboundGate(for childChannel: Channel) -> EventLoopFuture<Void> {
-        guard let record = self.streamRecords[ObjectIdentifier(childChannel)] else {
-            return childChannel.eventLoop.makeFailedFuture(
-                Errors.streamRejectedByGater(reason: "stream was torn down before it finished negotiating")
-            )
-        }
-        return record.inboundGate
-    }
-
-    /// Attach the muxer's `Stream` to our record and stamp the negotiation time.
-    /// - Note: Must be called on `self.eventLoop`.
-    private func resolveTrackedStream(_ stream: LibP2PCore.Stream, on childChannel: Channel) {
-        let key = ObjectIdentifier(childChannel)
-        guard var record = self.streamRecords[key] else { return }
-        record.stream = stream
-        record.negotiatedAt = Date()
-        self.streamRecords[key] = record
-    }
-
-    /// Schedule a prune
-    /// - Note: Must be called on `self.eventLoop`.
-    private func armPruneSweep() {
-        guard let interval = self.streamPruner.sweepInterval else {
-            self.logger.trace("StreamPruner disabled sweeping; not scheduling a sweep task")
-            return
-        }
-        guard self.pruneSweepTask == nil else { return }
-        self.logger.trace("Sweeping for prunable streams every \(interval.asSeconds)s")
-        self.pruneSweepTask = self.eventLoop.scheduleRepeatedTask(initialDelay: interval, delay: interval) {
-            [weak self] _ in
-            self?.sweepForPrunableStreams()
-        }
-    }
-
-    private func cancelPruneSweep() {
-        self.pruneSweepTask?.cancel()
-        self.pruneSweepTask = nil
-    }
-
-    /// Whether a prune sweep is currently armed.
-    /// - Note: `internal` only so tests can assert we neither leak nor skip the sweep.
-    internal var hasPruneSweepScheduled: Bool {
-        self.pruneSweepTask != nil
-    }
-
-    /// Arms the sweep without going through a full security + muxer upgrade.
-    /// - Note: `internal` only so tests can exercise the scheduling decision directly.
-    internal func armPruneSweepForTesting() {
-        self.armPruneSweep()
-    }
-
-    /// One pruning pass: snapshot on the loop, decide on the actor, apply back on the loop.
-    /// - Note: Must be called on `self.eventLoop`.
-    private func sweepForPrunableStreams() {
-        guard self.stats.status != .closing, self.stats.status != .closed else { return }
-        guard !self.streamRecords.isEmpty else { return }
-
-        let snapshots = self.streamRecords.map { key, record in
-            StreamLivenessSnapshot(
-                key: key,
-                id: record.stream?.id ?? 0,
-                direction: record.direction,
-                state: record.stream?.streamState ?? .initialized,
-                protocolCodec: record.stream?.protocolCodec ?? "",
-                openedAt: record.openedAt,
-                negotiatedAt: record.negotiatedAt,
-                lastActivityAt: record.activity.lastActivityAt
-            )
-        }
-
-        let pruner = self.streamPruner
-        let now = Date()
-        let eventLoop = self.eventLoop
-        Task { [weak self] in
-            let actions = await pruner.prune(snapshots, now: now)
-            guard !actions.isEmpty else { return }
-            eventLoop.execute {
-                self?.applyPruneActions(actions)
-            }
-        }
-    }
-
-    /// Apply the results of the pruner (closing / reseting the streams)
-    /// - Note: Must be called on `self.eventLoop`.
-    private func applyPruneActions(_ actions: [ObjectIdentifier: StreamPruneAction]) {
-        for (key, action) in actions {
-            /// The record may already be gone — the stream could have closed while the pruner was
-            /// deciding — so re-resolve rather than trusting the snapshot.
-            guard let record = self.streamRecords.removeValue(forKey: key) else { continue }
-            guard record.channel.isActive else { continue }
-
-            let description =
-                "Stream[\(record.stream?.id.description ?? "?")][\(record.stream?.protocolCodec ?? "unnegotiated")][\(record.direction)]"
-            self.logger.debug("Pruning \(description) (\(action))")
-
-            switch action {
-            case .reset:
-                if let stream = record.stream {
-                    let _ = stream.reset()
-                } else {
-                    self.muxer?.removeStream(channel: record.channel)
-                }
-            case .close:
-                if let stream = record.stream {
-                    let _ = stream.close(gracefully: true)
-                } else {
-                    self.muxer?.removeStream(channel: record.channel)
-                }
-            }
-        }
-    }
-
-    // MARK: - Opening streams
-
-    public func newStream(_ protos: [String]) -> EventLoopFuture<LibP2PCore.Stream> {
-        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
-    }
-
+extension BaseConnection {
+    
     public enum NewStreamMode {
         case openStream
         case ifOneDoesntAlreadyExist
@@ -977,17 +388,21 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     }
 
     private struct StreamCache {
+        /// Distinguishes two requests for the same protocol, so a refusal removes the right one.
+        let id: UUID
         let proto: String
         let responder: Responder
 
         init(proto: String, responder: Responder) {
+            self.id = UUID()
             self.proto = proto
             self.responder = responder
         }
     }
-
-    private var newStreamCache: [StreamCache] = []
-    private var pendingStreamCache: [StreamCache] = []
+    
+    public func newStream(_ protos: [String]) -> EventLoopFuture<LibP2PCore.Stream> {
+        self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+    }
 
     /// Opens an outbound stream delegating to a uniquely specified handler / responder
     public func newStream(
@@ -1037,68 +452,97 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
         )
 
         self.eventLoop.execute {
-            /// If the connection has already closed (e.g. a coalesced cold dial whose shared
-            /// connection failed to upgrade), fail fast instead of queueing a stream that will never
-            /// open and would otherwise only surface as a timeout.
+            // If the connection has already closed (e.g. a coalesced cold dial whose shared
+            // connection failed to upgrade), fail fast instead of queueing a stream that will never
+            // open and would otherwise only surface as a timeout.
             guard self.stats.status != .closed && self.stats.status != .closing else {
                 self.logger.debug("Refusing new `\(proto)` stream — connection is \(self.stats.status)")
                 self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
                 return
             }
-            /// Cancel and clear our idleTimeoutTask if we have one
+            // Cancel and clear our idleTimeoutTask if we have one
             self.cancelTimeoutTask()
-            /// Ask our muxer to open the stream...
-            if self.isMuxed, let mux = self.muxer {
-                /// Store our responder
-                self.logger.trace("Adding `\(proto)` to our newStreamCache")
-                self.newStreamCache.append(pendingStream)
-                /// Ask our installed Muxer to open / initialize a new stream for us...
-                self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
-                do {
-                    let streamFuture = try mux.newStream(channel: self.channel, proto: proto)
-                    streamFuture.whenFailure { error in
-                        self.logger.error("Muxer failed to open new stream for protocol `\(proto)`: \(error)")
-                    }
-                } catch {
-                    self.logger.error("Muxer threw while opening new stream for protocol `\(proto)`: \(error)")
-                }
-
+            // Ask our muxer to open the stream...
+            if self.isMuxed, self.muxer != nil {
+                self.openStream(pendingStream)
             } else {
-                /// Store our responder
+                // Store our responder. We'll gate and open it in `onMuxed`, once we know who we're
+                // talking to.
                 self.logger.trace("Adding `\(proto)` to our pendingStreamCache")
                 self.pendingStreamCache.append(pendingStream)
             }
         }
     }
 
-    /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
-    /// `newRequest`) fails immediately instead of waiting for a timeout.
-    private func fail(_ stream: StreamCache, with error: Error) {
-        let errorRequest = Request(
-            application: self.application,
-            event: .error(error),
-            streamDirection: .outbound,
-            connection: self,
-            channel: self.channel,
-            logger: self.logger,
-            on: self.channel.eventLoop
-        )
-        let _ = stream.responder.respond(to: errorRequest)
-    }
+    /// Asks the `StreamGater` about a proposed outbound stream and, if it approves, asks the muxer to
+    /// open a child channel for it.
+    ///
+    /// Gating here rather than after negotiation means a refusal costs nothing: no child channel, no mss
+    /// exchange, no pipeline to unwind. The caller hears about it through their `Responder`, the same way
+    /// they'd hear about any other failure to open the stream.
+    /// - Note: Must be called on `self.eventLoop`, on a muxed connection.
+    private func openStream(_ pendingStream: StreamCache) {
+        let proto = pendingStream.proto
 
-    /// Fails and clears every stream still waiting to be opened. Invoked when the connection closes
-    /// before it finished upgrading, so any queued (including coalesced cold-dial) requests fail fast.
-    private func failQueuedStreams(_ error: Error) {
-        let queued = self.pendingStreamCache + self.newStreamCache
-        self.pendingStreamCache = []
-        self.newStreamCache = []
-        guard !queued.isEmpty else { return }
-        self.logger.debug("Failing \(queued.count) queued stream(s) due to: \(error)")
-        for stream in queued {
-            self.fail(stream, with: error)
+        guard let remotePeer = self.remotePeer, let remoteAddress = self.remoteAddr else {
+            // This should be unreachable, we're secured, so we shold have a remote peer.
+            self.logger.error("Refusing outbound `\(proto)` stream — connection has no authenticated remote peer")
+            self.fail(pendingStream, with: Errors.streamRejectedByGater(reason: "no authenticated remote peer"))
+            return
+        }
+
+        // Register the request before consulting the gater.
+        self.logger.trace("Adding `\(proto)` to our newStreamCache")
+        self.newStreamCache.append(pendingStream)
+
+        let context = OutboundStreamGateContext(
+            connectionID: self.id,
+            remotePeer: remotePeer,
+            remoteAddress: remoteAddress,
+            protocolCodec: proto,
+            openStreamCount: self.muxer?.streams.count ?? 0
+        )
+        let gater = self.streamGater
+        self.consultGater({ await gater.shouldAllowOutboundStream(context) }) { [weak self] decision in
+            guard let self = self else { return }
+
+            if case .reject(let reason) = decision {
+                self.logger.notice("StreamGater rejected outbound `\(proto)` stream: \(reason)")
+                self.newStreamCache.removeAll { $0.id == pendingStream.id }
+                self.fail(pendingStream, with: Errors.streamRejectedByGater(reason: reason))
+                // Nothing was opened, so no stream will ever close to trigger it; re-arm the idle
+                // teardown ourselves. (It re-checks both caches before actually closing.)
+                if self.streams.isEmpty {
+                    self.armTimeoutTask()
+                }
+                return
+            }
+
+            guard let mux = self.muxer else {
+                self.logger.debug("Muxer went away before `\(proto)` could be opened")
+                self.newStreamCache.removeAll { $0.id == pendingStream.id }
+                self.fail(pendingStream, with: Application.Connections.Errors.connectionUpgradeFailed)
+                return
+            }
+
+            // Ask our installed Muxer to open / initialize a new stream for us...
+            self.logger.debug("Asking Muxer to open / initialize new stream for protocol `\(proto)`")
+            do {
+                try mux.newStream(channel: self.channel, proto: proto).whenFailure { error in
+                    self.logger.error("Muxer failed to open new stream for protocol `\(proto)`: \(error)")
+                    self.newStreamCache.removeAll { $0.id == pendingStream.id }
+                    self.fail(pendingStream, with: error)
+                }
+            } catch {
+                self.logger.error("Muxer threw while opening new stream for protocol `\(proto)`: \(error)")
+                self.newStreamCache.removeAll { $0.id == pendingStream.id }
+                self.fail(pendingStream, with: error)
+            }
         }
     }
-
+    
+    /// - Warning: Not gated. Consulting a ``StreamGater`` means awaiting an actor. Use the asynchronous
+    ///   `newStream(forProtocol:)` family if the gater's policy needs to apply.
     public func newStreamSync(_ proto: String) throws -> LibP2PCore.Stream {
         let stream: _Stream
         if isMuxed, let mux = self.muxer {
@@ -1127,15 +571,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     public func newStreamHandlerSync(_ proto: String) throws -> StreamHandler {
         throw Application.Connections.Errors.notImplementedYet
     }
-
-    public func removeStream(id: UInt64) -> EventLoopFuture<Void> {
-        if let stream = self.registry.removeValue(forKey: id) {
-            return stream.close(gracefully: true)
-        } else {
-            return self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.noStreamForID(id))
-        }
-    }
-
+    
     public func acceptStream(_ stream: LibP2PCore.Stream, protocol: String, metadata: [String]) -> EventLoopFuture<Bool>
     {
         self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
@@ -1149,9 +585,665 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) })
         }
     }
+    
+    /// Called by our Muxer when a new stream has been opened
+    /// - Note: We take this opportunity to cancel the idleTimeoutTask if one exists.
+    private func onNewStream(_ stream: LibP2PCore.Stream) {
+        self.eventLoop.execute {
+            self.cancelTimeoutTask()
+            self.logger.trace("Notified of new stream, canceling existing idleTimeoutTask")
+        }
+    }
+}
 
-    // MARK: - Closing
+// MARK: - Stream Teardown / Cleanup
+extension BaseConnection {
+    
+    /// Called by our Muxer when a stream of ours has been closed.
+    /// - Note: We take this opportunity to check if there are any active streams and kick off our
+    ///   idleTimeoutTask if there aren't.
+    private func onStreamClosed(_ stream: LibP2PCore.Stream) {
+        self.logger.trace("On Stream Closed...")
+        guard let mux = self.muxer else {
+            self.logger.trace("No Muxer Available")
+            return
+        }
+        if mux.streams.isEmpty {
+            self.logger.trace("No Streams")
+            if self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty {
+                self.logger.trace("No Pending Streams")
+                self.armTimeoutTask()
+            }
+        } else {
+            self.logger.trace("We still have \(mux.streams.count) streams")
+            self.logger.trace(
+                "\(mux.streams.map { "Stream[\($0.id)][\($0.protocolCodec)][\($0.direction)][\($0.streamState)]" }.joined(separator: "\n") )"
+            )
+        }
+    }
+    
+    /// Tears down a stream we've decided to prune.
+    ///
+    /// A rejection is treated as a `.reset`. Otherwise the stream would sit idle until it's timeout fired.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func abandonStream(on childChannel: Channel) {
+        self.untrackStream(on: childChannel)
+        guard let stream = self.muxer?.streams.first(where: { $0.channel === childChannel }) else {
+            /// A stream the muxer doesn't surface yet has no reset to send; fall back to its
+            /// channel-level teardown.
+            self.muxer?.removeStream(channel: childChannel)
+            return
+        }
+        let _ = stream.reset()
+    }
+    
+    private func cancelTimeoutTask() {
+        self.idleTimeoutTask?.cancel()
+        self.idleTimeoutTask = nil
+    }
+    
+    private func armTimeoutTask() {
+        guard self.idleTimeoutTask == nil else { return }
+        self.idleTimeoutTask = self.eventLoop.scheduleTask(in: .milliseconds(self.idleTimeoutMilliseconds)) {
+            // Close ourself and notify our connection manager
+            guard self.newStreamCache.isEmpty && self.pendingStreamCache.isEmpty else {
+                self.idleTimeoutTask = nil
+                return
+            }
+            self.logger.debug("Idle timeout reached. Terminating self")
+            let _ = self.close()
+        }
+    }
+    
+    /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
+    /// `newRequest`) fails immediately instead of waiting for a timeout.
+    private func fail(_ stream: StreamCache, with error: Error) {
+        self.fail(stream.responder, with: error)
+    }
 
+    private func fail(_ responder: Responder, with error: Error) {
+        let errorRequest = Request(
+            application: self.application,
+            event: .error(error),
+            streamDirection: .outbound,
+            connection: self,
+            channel: self.channel,
+            logger: self.logger,
+            on: self.channel.eventLoop
+        )
+        let _ = responder.respond(to: errorRequest)
+    }
+
+    /// Reports a stream that closed before its pipeline could be configured to whoever asked for it.
+    ///
+    /// Only outbound streams have such a caller.
+    private func failPendingCaller(
+        _ responder: Responder,
+        direction: ConnectionStats.Direction,
+        with error: Error
+    ) {
+        guard direction == .outbound else { return }
+        self.fail(responder, with: error)
+    }
+
+    /// Fails and clears every stream still waiting to be opened. Invoked when the connection closes
+    /// before it finished upgrading, so any queued (including coalesced cold-dial) requests fail fast.
+    private func failQueuedStreams(_ error: Error) {
+        let queued = self.pendingStreamCache + self.newStreamCache
+        self.pendingStreamCache = []
+        self.newStreamCache = []
+        guard !queued.isEmpty else { return }
+        self.logger.debug("Failing \(queued.count) queued stream(s) due to: \(error)")
+        for stream in queued {
+            self.fail(stream, with: error)
+        }
+    }
+    
+    public func removeStream(id: UInt64) -> EventLoopFuture<Void> {
+        if let stream = self.registry.removeValue(forKey: id) {
+            return stream.close(gracefully: true)
+        } else {
+            return self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.noStreamForID(id))
+        }
+    }
+}
+
+// MARK: - Child Channel Ingress / Egress
+
+extension BaseConnection {
+    
+    /// This function gets called by our Muxer when instantiating a new inbound child Channel.
+    /// Take this opportunity to configure the child channel's pipeline before data transmission begins.
+    ///
+    /// Because our StreamGater's decision is asynchronous, and some muxers may not support buffering
+    /// inbound data on unactivated stream (yamux), we install a `StreamGateBuffer` handler imediately
+    /// on the pipeline, whose sole job is to buffer unbound reads while we wait for the StreamGater's
+    /// veridict. If the stream is approved, MSS is configured and installed, then the buffer removed, causing
+    /// the buffered bytes to flow into MSS. If the stream is rejected, we reset / tear down the child channel
+    /// and discard the buffered bytes.
+    /// - TODO: Maybe instead of an abrupt reset / tear down on rejection, we should just install the MSS
+    /// with an empty list of protocols, this way the peer would get a response instead of an abrupt reset.
+    public func inboundMuxedChildChannelInitializer(_ childChannel: Channel) -> EventLoopFuture<Void> {
+        // Cancel our idleTimeoutTask if we have one
+        self.cancelTimeoutTask()
+        
+        // Start tracking the stream for pruning purposes right away — a stream that never negotiates
+        // is exactly the sort of thing the pruner exists to reap.
+        self.trackStream(on: childChannel, direction: .inbound)
+        
+        guard let remotePeer = self.remotePeer, let remoteAddress = self.remoteAddr else {
+            // This should be unreachable. `onSecured` closes any connection that doesn't yeild a
+            // remote peer
+            self.logger.error("Refusing inbound stream — connection has no authenticated remote peer")
+            self.untrackStream(on: childChannel)
+            return childChannel.eventLoop.makeFailedFuture(
+                Errors.streamRejectedByGater(reason: "connection has no authenticated remote peer")
+            )
+        }
+        
+        let supported = self.supportedProtocols
+        
+        // Hold anything the remote pipelines behind its stream-open until we have a verdict.
+        let buffered = childChannel.pipeline.addHandler(
+            StreamGateBuffer(logger: self.logger),
+            name: StreamGateBuffer.handlerName,
+            position: .last
+        )
+        
+        let context = InboundStreamGateContext(
+            connectionID: self.id,
+            remotePeer: remotePeer,
+            remoteAddress: remoteAddress,
+            supportedProtocols: supported,
+            openStreamCount: self.muxer?.streams.count ?? 0
+        )
+        let gater = self.streamGater
+        self.consultGater({ await gater.shouldAcceptInboundStream(context) }) { [weak self] decision in
+            self?.applyInboundGateDecision(decision, on: childChannel, supporting: supported)
+        }
+        
+        return buffered
+    }
+    
+    /// Installs the multistream-select listener on an accepted inbound child channel, restricted to the
+    /// protocols the gater approved, then releases the bytes the gate buffer has been holding.
+    private func configureInboundUpgrader(on childChannel: Channel, protocols: [String]) -> EventLoopFuture<Void> {
+        let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+        
+        self.logger.trace("Negotiating inbound stream over \(protocols.count) gater-approved protocol(s)")
+        
+        let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
+            protocols: protocols,
+            mode: .listener,
+            logger: self.logger,
+            promise: negotiationPromise
+        )
+        
+        negotiationPromise.futureResult.whenComplete { [weak self] result in
+            guard let self = self, self.application.isRunning else { return }
+            switch result {
+            case .failure(let error):
+                self.untrackStream(on: childChannel)
+                self.muxer?.removeStream(channel: childChannel)
+                self.logger.error("Error while upgrading Inbound ChildChannel: \(error)")
+                
+            case .success(let proto):
+                // Append a stream event in our stream history array
+                self.streamHistory.append(
+                    StreamStateEntry(
+                        proto: proto.protocol.description,
+                        direction: .inbound,
+                        state: .initialized,
+                        date: Date()
+                    )
+                )
+                
+                // Finish the upgrade
+                self.finishUpgrading(
+                    proto,
+                    childChannel: childChannel,
+                    responder: self.application.responder.current,
+                    direction: .inbound
+                )
+            }
+        }
+        
+        // MSS gets installed after the buffer so that it captures the replayed bytes upon the buffers removal
+        return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last).flatMap {
+            childChannel.pipeline.removeHandler(name: StreamGateBuffer.handlerName)
+        }
+    }
+    
+    /// This function gets called by our Muxer when instantiating a new outbound child Channel.
+    /// Take this opportunity to configure the child channel's pipeline for the specified protocol
+    /// before data transmission begins.
+    public func outboundMuxedChildChannelInitializer(_ childChannel: Channel, protocol: String) -> EventLoopFuture<Void>
+    {
+        self.eventLoop.flatSubmit {
+            // Cancel our idleTimeoutTask if we have one
+            self.cancelTimeoutTask()
+            
+            guard let idx = self.newStreamCache.firstIndex(where: { $0.proto == `protocol` }) else {
+                self.logger.error("No Responder For `\(`protocol`)`")
+                self.logger.error("\(self.newStreamCache)")
+                return childChannel.eventLoop.makeFailedFuture(Application.Connections.Errors.noResponder)
+            }
+            let pendingStream = self.newStreamCache.remove(at: idx)
+            
+            self.trackStream(on: childChannel, direction: .outbound)
+            
+            let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
+            let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
+                protocols: [`protocol`],
+                mode: .initiator,
+                logger: self.logger,
+                promise: negotiationPromise
+            )
+            
+            // Register our post negotiation callback
+            negotiationPromise.futureResult.whenComplete { [weak self] result in
+                guard let self = self, self.application.isRunning else { return }
+                switch result {
+                case .failure(let error):
+                    self.untrackStream(on: childChannel)
+                    self.muxer?.removeStream(channel: childChannel)
+                    self.logger.error("Error while upgrading Outbound ChildChannel: \(error)")
+                    
+                case .success(let proto):
+                    // Append a stream event in our stream history array
+                    self.streamHistory.append(
+                        StreamStateEntry(
+                            proto: proto.protocol.description,
+                            direction: .outbound,
+                            state: .initialized,
+                            date: Date()
+                        )
+                    )
+                    
+                    // Finish upgrading the child channel
+                    self.finishUpgrading(
+                        proto,
+                        childChannel: childChannel,
+                        responder: pendingStream.responder,
+                        direction: .outbound
+                    )
+                }
+            }
+            
+            // Kick off the negotiation
+            return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
+        }
+    }
+    
+    /// Install the route's handlers, record the stream, and announce it.
+    private func finishUpgrading(
+        _ proto: NegotiationResult,
+        childChannel: Channel,
+        responder: Responder,
+        direction: ConnectionStats.Direction
+    ) {
+        // Just tripple check that the channel is still active before proceeding.
+        guard childChannel.isActive else {
+            self.logger.debug(
+                "`\(proto.protocol)` stream closed before its pipeline could be configured; skipping it"
+            )
+            self.untrackStream(on: childChannel)
+            self.failPendingCaller(responder, direction: direction, with: ChannelError.ioOnClosedChannel)
+            return
+        }
+        
+        // Install the responder and finalize the child channel upgrade.
+        self.upgradeChildChannel(
+            proto,
+            childChannel: childChannel,
+            responder: responder,
+            direction: direction
+        ).whenComplete { [weak self] result in
+            guard let self = self, self.application.isRunning else { return }
+            
+            // Append a stream event in our stream history array
+            self.streamHistory.append(
+                StreamStateEntry(proto: proto.protocol, direction: direction, state: .open, date: Date())
+            )
+            
+            self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
+            self.logger.debug("🔀 New \(direction) ChildChannel[`\(proto)`] Ready!")
+            self.logger.trace("List of Streams:")
+            self.logger.trace(
+                "\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))"
+            )
+            
+            // The pipeline never finished being configured — the stream closed mid-upgrade, or the
+            // muxer went away — so, as above, there's no handler on it to report the failure.
+            if case .failure(let error) = result {
+                self.failPendingCaller(responder, direction: direction, with: error)
+                return
+            }
+            
+            // Post about the new stream on our application's Event Bus
+            guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
+            str._connection.withLockedValue { $0 = self }
+            // Now that the muxer has a fully formed Stream for this channel, hand it to the pruner's
+            // bookkeeping so eviction can go through the Stream API rather than the raw channel.
+            self.resolveTrackedStream(str, on: childChannel)
+            self.application.events.post(.openedStream(str))
+            childChannel.closeFuture.whenComplete { [weak self] _ in
+                guard let self = self else { return }
+                // Append a stream event in our stream history array
+                self.streamHistory.append(
+                    StreamStateEntry(proto: proto.protocol, direction: direction, state: .closed, date: Date())
+                )
+                self.application.events.post(.closedStream(str))
+            }
+        }
+    }
+    
+    /// To be called when the childChannel's protocol negotiation completes
+    ///
+    /// Note: Also is responsible for forwarding any leftover bytes received during the childChannel
+    /// upgrade process
+    private func upgradeChildChannel(
+        _ proto: NegotiationResult,
+        childChannel: Channel,
+        responder: Responder,
+        direction: ConnectionStats.Direction
+    ) -> EventLoopFuture<Void> {
+        //Install the protocol on the channel's pipeline...
+        logger.trace("Negotiated \(proto)")
+        
+        guard let muxer = self.muxer else {
+            logger.debug("Muxer went away before `\(proto.protocol)` could be installed")
+            return childChannel.eventLoop.makeFailedFuture(
+                Application.Connections.Errors.connectionUpgradeFailed
+            )
+        }
+        guard var handlers = responder.pipelineConfig(for: proto.protocol, on: self) else {
+            // Unhandled protocol negotiated
+            logger.trace("Unhandled protocol negotiated `\(proto.protocol)`")
+            return childChannel.eventLoop.makeSucceededVoidFuture()
+        }
+        logger.trace("Attempting to install route (`\(proto)`) specific ChannelHandlers")
+        logger.trace("\(handlers.map({ String(describing: $0) }).joined(separator: ", "))")
+        
+        // Prepare our activity monitor for the Encoder / Decoder handlers
+        let activity = self.activityRecord(for: childChannel)
+        
+        // Prepare the Responder handlers for installation
+        handlers.append(
+            contentsOf: [
+                RequestEncoderChannelHandler(
+                    application: application,
+                    connection: self,
+                    protocol: proto.protocol,
+                    logger: logger,
+                    direction: direction,
+                    activity: activity
+                ),
+                ResponseDecoderChannelHandler(logger: logger, activity: activity),
+                ResponderChannelHandler(responder: responder, logger: logger),
+            ] as [ChannelHandler]
+        )
+        
+        let codec = proto.protocol
+        
+        // update our stream state
+        return muxer.updateStream(channel: childChannel, state: .open, proto: codec).flatMap {
+            () -> EventLoopFuture<Void> in
+            do {
+                // triple check that the stream is still active on the network
+                guard self.streamIsStillOpen(childChannel, proto: codec) else {
+                    throw ChannelError.ioOnClosedChannel
+                }
+                let pipeline = childChannel.pipeline.syncOperations
+                // add the prepared Responder handlers behind the mss upgrader
+                try pipeline.addHandlers(handlers, position: .last)
+                // remove the mss upgrader, flushing the buffered bytes
+                return pipeline.removeHandler(name: "upgrader").map {
+                    // if our upgrader returned leftover bytes...
+                    guard let lo = proto.leftoverBytes, lo.readableBytes > 0 else {
+                        return
+                    }
+                    // forward them down the pipeline
+                    self.logger.trace("Forwarding leftover bytes along pipeline...")
+                    childChannel.pipeline.fireChannelRead(NIOAny(proto.leftoverBytes))
+                }
+            } catch {
+                return childChannel.eventLoop.makeFailedFuture(error)
+            }
+        }
+    }
+    
+    /// Whether it's still worth touching `childChannel.pipeline`.
+    private func streamIsStillOpen(_ childChannel: Channel, proto: String) -> Bool {
+        guard childChannel.isActive else {
+            self.logger.debug("`\(proto)` stream closed mid-upgrade; abandoning its pipeline")
+            return false
+        }
+        return true
+    }
+}
+
+// MARK: - Stream gating
+
+extension BaseConnection {
+    
+    /// The protocols our application supports (the gater can return a subset of these)
+    private var supportedProtocols: [String] {
+        self.application.routes.all.map { $0.description }
+    }
+    
+    /// Asks the gater for a verdict and delivers it back on our event loop.
+    private func consultGater<Decision: Sendable>(
+        _ ask: @escaping @Sendable () async -> Decision,
+        then apply: @escaping @Sendable (Decision) -> Void
+    ) {
+        let eventLoop = self.eventLoop
+        Task {
+            let decision = await ask()
+            eventLoop.execute { apply(decision) }
+        }
+    }
+    
+    /// Narrows our supported protocols down to what the gater approved.
+    private func approvedProtocols(
+        _ decision: InboundStreamGateDecision,
+        from supported: [String]
+    ) -> [String] {
+        switch decision {
+        case .accept:
+            return supported
+        case .acceptFor(let protocols):
+            // Intersect the returned protocols with the protocols we actually support
+            // - Note: discards any unknown protocols the gater returns
+            let approved = Set(protocols)
+            return supported.filter { approved.contains($0) }
+        case .reject:
+            return []
+        }
+    }
+    
+    /// Applies the gater's verdict to an inbound stream whose bytes a ``StreamGateBuffer`` has been
+    /// holding: either install mss for the approved protocols, or reset the stream having negotiated
+    /// nothing at all.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func applyInboundGateDecision(
+        _ decision: InboundStreamGateDecision,
+        on childChannel: Channel,
+        supporting supported: [String]
+    ) {
+        guard self.application.isRunning else { return }
+        
+        if case .reject(let reason) = decision {
+            self.logger.notice("StreamGater rejected inbound stream: \(reason)")
+            self.abandonStream(on: childChannel)
+            return
+        }
+        
+        let approved = self.approvedProtocols(decision, from: supported)
+        guard !approved.isEmpty else {
+            self.logger.notice("StreamGater left no supported protocols for this inbound stream; rejecting it")
+            self.abandonStream(on: childChannel)
+            return
+        }
+        
+        // approved, proceed with the upgrade using the approved protocols
+        self.configureInboundUpgrader(on: childChannel, protocols: approved).whenFailure { [weak self] error in
+            guard let self = self else { return }
+            if childChannel.isActive {
+                self.logger.error("Failed to configure the approved inbound stream: \(error)")
+            } else {
+                self.logger.debug("Inbound stream closed while it was being gated: \(error)")
+            }
+            self.abandonStream(on: childChannel)
+        }
+    }
+}
+
+// MARK: - Stream pruning
+
+extension BaseConnection {
+    
+    /// Begin tracking a child channel. Called the moment we learn of a stream, negotiated or not.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func trackStream(
+        on childChannel: Channel,
+        direction: ConnectionStats.Direction
+    ) {
+        let key = ObjectIdentifier(childChannel)
+        guard self.streamRecords[key] == nil else { return }
+        self.streamRecords[key] = StreamRecord(
+            channel: childChannel,
+            direction: direction,
+            openedAt: Date(),
+            activity: StreamActivityRecord(),
+            stream: nil,
+            negotiatedAt: nil
+        )
+        // Clear the record when the channel goes away
+        childChannel.closeFuture.whenComplete { [weak self] _ in
+            self?.streamRecords.removeValue(forKey: key)
+        }
+    }
+    
+    /// - Note: Must be called on `self.eventLoop`.
+    private func untrackStream(on childChannel: Channel) {
+        self.streamRecords.removeValue(forKey: ObjectIdentifier(childChannel))
+    }
+    
+    /// - Note: Must be called on `self.eventLoop`.
+    private func activityRecord(for childChannel: Channel) -> StreamActivityRecord? {
+        self.streamRecords[ObjectIdentifier(childChannel)]?.activity
+    }
+    
+    /// Attach the muxer's `Stream` to our record and stamp the negotiation time.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func resolveTrackedStream(_ stream: LibP2PCore.Stream, on childChannel: Channel) {
+        let key = ObjectIdentifier(childChannel)
+        guard var record = self.streamRecords[key] else { return }
+        record.stream = stream
+        record.negotiatedAt = Date()
+        self.streamRecords[key] = record
+    }
+    
+    /// Schedule a prune
+    /// - Note: Must be called on `self.eventLoop`.
+    private func armPruneSweep() {
+        guard let interval = self.streamPruner.sweepInterval else {
+            self.logger.trace("StreamPruner disabled sweeping; not scheduling a sweep task")
+            return
+        }
+        guard self.pruneSweepTask == nil else { return }
+        self.logger.trace("Sweeping for prunable streams every \(interval.asSeconds)s")
+        self.pruneSweepTask = self.eventLoop.scheduleRepeatedTask(initialDelay: interval, delay: interval) {
+            [weak self] _ in
+            self?.sweepForPrunableStreams()
+        }
+    }
+    
+    private func cancelPruneSweep() {
+        self.pruneSweepTask?.cancel()
+        self.pruneSweepTask = nil
+    }
+    
+    /// Whether a prune sweep is currently armed.
+    /// - Note: `internal` only so tests can assert we neither leak nor skip the sweep.
+    internal var hasPruneSweepScheduled: Bool {
+        self.pruneSweepTask != nil
+    }
+    
+    /// Arms the sweep without going through a full security + muxer upgrade.
+    /// - Note: `internal` only so tests can exercise the scheduling decision directly.
+    internal func armPruneSweepForTesting() {
+        self.armPruneSweep()
+    }
+    
+    /// One pruning pass: snapshot on the loop, decide on the actor, apply back on the loop.
+    /// - Note: Must be called on `self.eventLoop`.
+    private func sweepForPrunableStreams() {
+        guard self.stats.status != .closing, self.stats.status != .closed else { return }
+        guard !self.streamRecords.isEmpty else { return }
+        
+        let snapshots = self.streamRecords.map { key, record in
+            StreamLivenessSnapshot(
+                key: key,
+                id: record.stream?.id ?? 0,
+                direction: record.direction,
+                state: record.stream?.streamState ?? .initialized,
+                protocolCodec: record.stream?.protocolCodec ?? "",
+                openedAt: record.openedAt,
+                negotiatedAt: record.negotiatedAt,
+                lastActivityAt: record.activity.lastActivityAt
+            )
+        }
+        
+        let pruner = self.streamPruner
+        let now = Date()
+        let eventLoop = self.eventLoop
+        Task { [weak self] in
+            let actions = await pruner.prune(snapshots, now: now)
+            guard !actions.isEmpty else { return }
+            eventLoop.execute {
+                self?.applyPruneActions(actions)
+            }
+        }
+    }
+    
+    /// Apply the results of the pruner (closing / reseting the streams)
+    /// - Note: Must be called on `self.eventLoop`.
+    private func applyPruneActions(_ actions: [ObjectIdentifier: StreamPruneAction]) {
+        for (key, action) in actions {
+            /// The record may already be gone — the stream could have closed while the pruner was
+            /// deciding — so re-resolve rather than trusting the snapshot.
+            guard let record = self.streamRecords.removeValue(forKey: key) else { continue }
+            guard record.channel.isActive else { continue }
+            
+            let description =
+            "Stream[\(record.stream?.id.description ?? "?")][\(record.stream?.protocolCodec ?? "unnegotiated")][\(record.direction)]"
+            self.logger.debug("Pruning \(description) (\(action))")
+            
+            switch action {
+            case .reset:
+                if let stream = record.stream {
+                    let _ = stream.reset()
+                } else {
+                    self.muxer?.removeStream(channel: record.channel)
+                }
+            case .close:
+                if let stream = record.stream {
+                    let _ = stream.close(gracefully: true)
+                } else {
+                    self.muxer?.removeStream(channel: record.channel)
+                }
+            }
+        }
+    }
+}
+
+
+// MARK: - Connection Closing
+
+extension BaseConnection {
+    
     /// Called as soon as there is a request to close the Connection (internally via the connection
     /// manager, or externally via the user)
     internal func onClosing() -> EventLoopFuture<Void> {
@@ -1160,7 +1252,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             self.logger.trace("Closing")
         }
     }
-
+    
     public func close() -> EventLoopFuture<Void> {
         self.registry = [:]
         self.cancelTimeoutTask()
@@ -1172,7 +1264,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
                 let timeout = self.eventLoop.scheduleTask(in: .seconds(1)) {
                     closePromise.fail(Application.Connections.Errors.failedToCloseAllStreams)
                 }
-
+                
                 closePromise.completeWith(
                     self.streams.map { $0.close(gracefully: true) }.flatten(on: self.eventLoop).flatMapAlways {
                         result -> EventLoopFuture<Void> in
@@ -1200,7 +1292,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
                         }
                     }
                 )
-
+                
                 return closePromise.futureResult.flatMapAlways { res in
                     self.stats.status = .closed
                     switch res {
@@ -1216,7 +1308,11 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             }
         }
     }
+}
 
+// MARK: - Errors
+
+extension BaseConnection {
     public enum Errors: Error {
         /// A ``StreamGater`` refused a stream.
         case streamRejectedByGater(reason: String)
@@ -1227,52 +1323,97 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
 
 extension BaseConnection {
 
+    /// Tracks the connection's lifecycle, and the identity of the peer on the other end of it.
+    ///
+    /// The remote peer is part of the state rather than a free-standing property because it isn't
+    /// independently optional: it's unknown while we're `.raw` and known from `.secured` onwards. A
+    /// security handshake that yields no peer tears the connection down (see ``onSecured(_:)``), so
+    /// every path that runs after the upgrade — stream gating especially — can rely on having one.
     public struct ConnectionStateMachine {
-        internal private(set) var state: ConnectionState
+        /// `ConnectionState` is a shared, payload-free enum in `swift-libp2p-core`, so the peer lives
+        /// here instead of on it.
+        private enum Machine {
+            case raw
+            case secured(PeerID)
+            case muxed(PeerID)
+            case upgraded(PeerID)
+            case closed(PeerID?)
+        }
+        private var machine: Machine
 
-        internal init() {
-            self.state = .raw
+        internal var state: ConnectionState {
+            switch self.machine {
+            case .raw: return .raw
+            case .secured: return .secured
+            case .muxed: return .muxed
+            case .upgraded: return .upgraded
+            case .closed: return .closed
+            }
         }
 
-        internal mutating func secureConnection() throws {
-            switch state {
+        /// The authenticated remote peer, or `nil` if the security handshake hasn't completed yet.
+        internal var remotePeer: PeerID? {
+            switch self.machine {
+            case .raw: return nil
+            case .secured(let peer), .muxed(let peer), .upgraded(let peer): return peer
+            case .closed(let peer): return peer
+            }
+        }
+
+        internal init() {
+            self.machine = .raw
+        }
+
+        internal mutating func secureConnection(remotePeer: PeerID) throws {
+            switch self.machine {
             case .raw:
-                self.state = .secured
+                self.machine = .secured(remotePeer)
             case .secured, .muxed, .upgraded, .closed:
                 throw StateTransitionError.invalidStateTransition
             }
         }
 
         internal mutating func muxConnection() throws {
-            switch state {
-            case .secured:
-                self.state = .muxed
+            switch self.machine {
+            case .secured(let peer):
+                self.machine = .muxed(peer)
             case .raw, .muxed, .upgraded, .closed:
                 throw StateTransitionError.invalidStateTransition
             }
         }
 
         internal mutating func upgradeConnection() throws {
-            switch state {
-            case .muxed:
-                self.state = .upgraded
+            switch self.machine {
+            case .muxed(let peer):
+                self.machine = .upgraded(peer)
             case .raw, .secured, .upgraded, .closed:
                 throw StateTransitionError.invalidStateTransition
             }
         }
 
         internal mutating func closeConnection() throws {
-            switch state {
+            switch self.machine {
             case .closed:
                 break
-            case .raw, .secured, .muxed, .upgraded:
-                self.state = .closed
+            case .raw:
+                self.machine = .closed(nil)
+            case .secured(let peer), .muxed(let peer), .upgraded(let peer):
+                self.machine = .closed(peer)
             }
         }
     }
 
     internal enum StateTransitionError: Error {
         case invalidStateTransition
+    }
+    
+    /// Drives the state machine to `.muxed(remotePeer)` without running a real security or muxer
+    /// handshake, so a test can exercise the stream paths (which need an authenticated peer to build a
+    /// gate context) against a hand-installed muxer.
+    /// - Note: `internal` only so tests can stand a connection up directly.
+    internal func markSecuredForTesting(remotePeer: PeerID) throws {
+        try self.stateMachine.secureConnection(remotePeer: remotePeer)
+        try self.stateMachine.muxConnection()
     }
 }
 

--- a/Sources/LibP2P/Connections/BaseConnection.swift
+++ b/Sources/LibP2P/Connections/BaseConnection.swift
@@ -30,22 +30,22 @@ import Logging
 ///  app.connectionManager.use(streamPruner: )
 ///  ```
 public final class BaseConnection: AppConnection, @unchecked Sendable {
-    
+
     public let application: Application
-    
+
     public let channel: Channel
     private var eventLoop: EventLoop {
         self.channel.eventLoop
     }
-    
+
     public let id: UUID
-    
+
     public var localAddr: Multiaddr?
-    
+
     public var remoteAddr: Multiaddr?
-    
+
     public let localPeer: PeerID
-    
+
     /// The authenticated remote peer.
     ///
     /// Owned by ``stateMachine`` — `nil` until the security handshake completes, non-nil for the rest of
@@ -53,40 +53,40 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     public var remotePeer: PeerID? {
         self.stateMachine.remotePeer
     }
-    
+
     public var expectedRemotePeer: PeerID?
-    
+
     public let stats: ConnectionStats
-    
+
     public var tags: Any? = nil
-    
+
     public private(set) var registry: [UInt64: LibP2PCore.Stream] = [:]
-    
+
     public var streams: [LibP2PCore.Stream] {
         self.muxer?.streams ?? []
     }
-    
+
     public weak var muxer: Muxer? = nil
-    
+
     public var isMuxed: Bool = false
-    
+
     public var status: ConnectionStats.Status {
         self.stats.status
     }
-    
+
     public var timeline: [ConnectionStats.Status: Date] {
         self.stats.timeline.history
     }
-    
+
     /// Our Connection's Logger
     public var logger: Logger
-    
+
     /// Decides which streams we're willing to carry.
     private let streamGater: StreamGater
-    
+
     /// Decides which of our streams get evicted.
     private let streamPruner: StreamPruner
-    
+
     struct StreamStateEntry {
         let proto: String
         let direction: ConnectionStats.Direction
@@ -96,23 +96,23 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     /// Keep track of our Streams and thier lifecycle history.
     /// Feeds `lastActivity()`, which our ConnectionManager reads.
     internal private(set) var streamHistory: [StreamStateEntry] = []
-    
+
     private var stateMachine: ConnectionStateMachine
     public var state: ConnectionState {
         self.stateMachine.state
     }
-    
+
     /// These promises are used only once while upgrading the parent channel
     private let securedPromise: EventLoopPromise<SecuredResult>
     private let muxedPromise: EventLoopPromise<Muxer>
-    
+
     /// Whether each upgrade promise has been completed, so `deinit` can settle whatever is left
     private var securedPromiseSettled: Bool = false
     private var muxedPromiseSettled: Bool = false
-    
+
     /// The timestamp at which this connection was instantiated
     private let startTime: UInt64
-    
+
     /// The IdleTimeout Task that gets set each time our connection gets to zero open streams.
     /// We wait `idleTimeoutMilliseconds` for a new Stream to be opened. If one isn't opened in that
     /// window, the connection shuts down and deinits itself.
@@ -121,11 +121,11 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
     private var idleTimeoutTask: Scheduled<Void>? = nil
     /// The time in milliseconds that our connection will sit idle before terminating itself.
     private var idleTimeoutMilliseconds: Int64 = 250
-    
+
     /// Pending / Unopened Stream Caches
     private var newStreamCache: [StreamCache] = []
     private var pendingStreamCache: [StreamCache] = []
-    
+
     /// What we track per muxed stream so `streamPruner` can reason about liveness.
     ///
     /// Keyed by `ObjectIdentifier(childChannel)` rather than by stream `id`, because some muxer
@@ -140,11 +140,11 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
         var negotiatedAt: Date?
     }
     private var streamRecords: [ObjectIdentifier: StreamRecord] = [:]
-    
+
     /// The repeating sweep that asks our `streamPruner` what to evict.
     /// Started once we're muxed and cancelled on teardown.
     private var pruneSweepTask: RepeatedTask? = nil
-    
+
     public convenience init(
         application: Application,
         channel: Channel,
@@ -162,7 +162,7 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             streamPruner: application.connectionManager.streamPruner
         )
     }
-    
+
     /// Designated initializer, taking the gater and pruner explicitly.
     ///
     /// - Note: Designed to be used in Tests so we can explicitly install Gaters and Pruners
@@ -186,47 +186,47 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
         self.stateMachine = ConnectionStateMachine()
         self.streamGater = streamGater
         self.streamPruner = streamPruner
-        
+
         // Addresses
         self.localAddr = try? channel.localAddress?.toMultiaddr()
         self.remoteAddr = remoteAddress
-        
+
         // Peers
         self.localPeer = application.peerID
         self.expectedRemotePeer = expectedRemotePeer
-        
+
         // Metadata
         self.registry = [:]
         self.tags = nil
         self.stats = ConnectionStats(uuid: id, direction: direction)
-        
+
         // State Promises
         self.securedPromise = channel.eventLoop.makePromise(of: SecuredResult.self)
         self.muxedPromise = channel.eventLoop.makePromise(of: Muxer.self)
-        
+
         self.startTime = DispatchTime.now().uptimeNanoseconds
-        
+
         // Register our channel's close future
         self.channel.closeFuture.whenComplete { [weak self] _ in
             guard let self = self else { return }
             self.logger.trace("Channel -> CloseFuture")
             self.stats.status = .closed
-            
+
             // Teardown any tasks we've started
             self.cancelPruneSweep()
             self.cancelTimeoutTask()
-            
+
             // Fail any streams that were queued while we were still upgrading. If the channel closed
             // before we finished muxing, those streams will never open. Surface the failure to their
             // callers immediately (this is what fails coalesced cold dials when an upgrade fails)
             // rather than leaving each request to hit its own timeout.
             self.failQueuedStreams(Application.Connections.Errors.connectionUpgradeFailed)
-            
+
             // Should ensure that we actually connected before posting a disconnect event
             if self.application.isRunning {
                 self.application.events.post(.disconnected(self, self.remotePeer))
             }
-            
+
             self.muxer?.onStream = nil
             self.muxer?.onStreamEnd = nil
             self.muxer?._connection = nil
@@ -234,10 +234,10 @@ public final class BaseConnection: AppConnection, @unchecked Sendable {
             self.registry = [:]
             self.streamRecords = [:]
         }
-        
+
         self.logger.trace("Initialized")
     }
-    
+
     deinit {
         // Settle any upgrade promise the connection died still holding — an unfulfilled one is a
         // `fatalError` in debug builds.
@@ -265,22 +265,22 @@ extension BaseConnection {
             self.securedPromiseSettled = true
             self.onSecured(result)
         }
-        
+
         self.muxedPromise.futureResult.whenComplete { [weak self] result in
             guard let self = self else { return }
             self.muxedPromiseSettled = true
             self.onMuxed(result)
         }
-        
+
         self.stats.status = .opening
-        
+
         // Kickoff security upgrade (also responsible for negotiation)
         return self.secureConnection(promise: self.securedPromise).always { [weak self] _ in
             guard let self = self else { return }
             self.stats.status = .open
         }
     }
-    
+
     private func onSecured(_ result: Result<SecuredResult, Error>) {
         switch result {
         case .failure(let error):
@@ -292,7 +292,7 @@ extension BaseConnection {
                 self.logger.info(
                     "Secured with `\(security.securityCodec)`! RemotePeer: \(String(describing: security.remotePeer)), Warnings: \(String(describing: security.warning))"
                 )
-                
+
                 // A connection isn't considered secured unless we know who we're talking to
                 guard let remotePeer = security.remotePeer else {
                     self.logger.error(
@@ -301,14 +301,14 @@ extension BaseConnection {
                     self.channel.close(mode: .all, promise: nil)
                     return
                 }
-                
+
                 self.logger.info("Remote Address: \(self.remoteAddr?.description ?? "NIL")")
                 try self.stateMachine.secureConnection(remotePeer: remotePeer)
                 self.stats.encryption = security.securityCodec
-                
+
                 let pInfo = PeerInfo(peer: remotePeer, addresses: [])
                 self.application.events.post(.remotePeer(pInfo))
-                
+
                 // Kick off Muxer upgrade
                 self.muxConnection(promise: self.muxedPromise).whenComplete { res in
                     switch res {
@@ -327,7 +327,7 @@ extension BaseConnection {
             }
         }
     }
-    
+
     private func onMuxed(_ result: Result<Muxer, Error>) {
         switch result {
         case .failure(let error):
@@ -342,23 +342,23 @@ extension BaseConnection {
                 try self.stateMachine.muxConnection()
                 self.stats.status = .upgraded
                 self.stats.muxer = muxer.protocolCodec
-                
+
                 // Callbacks driving idle connection teardown
                 self.muxer?.onStream = self.onNewStream
                 self.muxer?.onStreamEnd = self.onStreamClosed
-                
+
                 let timeToUpgrade = DispatchTime.now().uptimeNanoseconds - self.startTime
                 self.logger.notice("Upgrade Time: \(timeToUpgrade / 1_000_000) ms")
-                
+
                 self.eventLoop.execute {
                     // Our connection is upgraded...
                     self.logger.trace("Our connection has been Secured and Muxed! We're ready to rock!")
                     self.application.events.post(.connected(self))
                     self.application.events.post(.upgraded(self))
-                    
+
                     // Now that streams are possible, start sweeping for dead ones.
                     self.armPruneSweep()
-                    
+
                     // Open any pending streams now that we're muxed.
                     // These go through the same gated path as a stream requested after the upgrade
                     let pending = self.pendingStreamCache
@@ -367,7 +367,7 @@ extension BaseConnection {
                         self.openStream(pendingStream)
                     }
                 }
-                
+
             } catch {
                 self.logger.error("Failed to mux channel: \(error)")
                 self.channel.close(mode: .all, promise: nil)
@@ -380,7 +380,7 @@ extension BaseConnection {
 // MARK: - Stream Opening
 
 extension BaseConnection {
-    
+
     public enum NewStreamMode {
         case openStream
         case ifOneDoesntAlreadyExist
@@ -399,7 +399,7 @@ extension BaseConnection {
             self.responder = responder
         }
     }
-    
+
     public func newStream(_ protos: [String]) -> EventLoopFuture<LibP2PCore.Stream> {
         self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
     }
@@ -540,7 +540,7 @@ extension BaseConnection {
             }
         }
     }
-    
+
     /// - Warning: Not gated. Consulting a ``StreamGater`` means awaiting an actor. Use the asynchronous
     ///   `newStream(forProtocol:)` family if the gater's policy needs to apply.
     public func newStreamSync(_ proto: String) throws -> LibP2PCore.Stream {
@@ -571,7 +571,7 @@ extension BaseConnection {
     public func newStreamHandlerSync(_ proto: String) throws -> StreamHandler {
         throw Application.Connections.Errors.notImplementedYet
     }
-    
+
     public func acceptStream(_ stream: LibP2PCore.Stream, protocol: String, metadata: [String]) -> EventLoopFuture<Bool>
     {
         self.channel.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
@@ -585,7 +585,7 @@ extension BaseConnection {
             return self.muxer?.streams.first(where: { ($0.protocolCodec == proto) })
         }
     }
-    
+
     /// Called by our Muxer when a new stream has been opened
     /// - Note: We take this opportunity to cancel the idleTimeoutTask if one exists.
     private func onNewStream(_ stream: LibP2PCore.Stream) {
@@ -598,7 +598,7 @@ extension BaseConnection {
 
 // MARK: - Stream Teardown / Cleanup
 extension BaseConnection {
-    
+
     /// Called by our Muxer when a stream of ours has been closed.
     /// - Note: We take this opportunity to check if there are any active streams and kick off our
     ///   idleTimeoutTask if there aren't.
@@ -621,7 +621,7 @@ extension BaseConnection {
             )
         }
     }
-    
+
     /// Tears down a stream we've decided to prune.
     ///
     /// A rejection is treated as a `.reset`. Otherwise the stream would sit idle until it's timeout fired.
@@ -636,12 +636,12 @@ extension BaseConnection {
         }
         let _ = stream.reset()
     }
-    
+
     private func cancelTimeoutTask() {
         self.idleTimeoutTask?.cancel()
         self.idleTimeoutTask = nil
     }
-    
+
     private func armTimeoutTask() {
         guard self.idleTimeoutTask == nil else { return }
         self.idleTimeoutTask = self.eventLoop.scheduleTask(in: .milliseconds(self.idleTimeoutMilliseconds)) {
@@ -654,7 +654,7 @@ extension BaseConnection {
             let _ = self.close()
         }
     }
-    
+
     /// Delivers an `.error` event to a queued stream's responder so its caller (e.g. a pending
     /// `newRequest`) fails immediately instead of waiting for a timeout.
     private func fail(_ stream: StreamCache, with error: Error) {
@@ -698,7 +698,7 @@ extension BaseConnection {
             self.fail(stream, with: error)
         }
     }
-    
+
     public func removeStream(id: UInt64) -> EventLoopFuture<Void> {
         if let stream = self.registry.removeValue(forKey: id) {
             return stream.close(gracefully: true)
@@ -711,7 +711,7 @@ extension BaseConnection {
 // MARK: - Child Channel Ingress / Egress
 
 extension BaseConnection {
-    
+
     /// This function gets called by our Muxer when instantiating a new inbound child Channel.
     /// Take this opportunity to configure the child channel's pipeline before data transmission begins.
     ///
@@ -726,11 +726,11 @@ extension BaseConnection {
     public func inboundMuxedChildChannelInitializer(_ childChannel: Channel) -> EventLoopFuture<Void> {
         // Cancel our idleTimeoutTask if we have one
         self.cancelTimeoutTask()
-        
+
         // Start tracking the stream for pruning purposes right away — a stream that never negotiates
         // is exactly the sort of thing the pruner exists to reap.
         self.trackStream(on: childChannel, direction: .inbound)
-        
+
         guard let remotePeer = self.remotePeer, let remoteAddress = self.remoteAddr else {
             // This should be unreachable. `onSecured` closes any connection that doesn't yeild a
             // remote peer
@@ -740,16 +740,16 @@ extension BaseConnection {
                 Errors.streamRejectedByGater(reason: "connection has no authenticated remote peer")
             )
         }
-        
+
         let supported = self.supportedProtocols
-        
+
         // Hold anything the remote pipelines behind its stream-open until we have a verdict.
         let buffered = childChannel.pipeline.addHandler(
             StreamGateBuffer(logger: self.logger),
             name: StreamGateBuffer.handlerName,
             position: .last
         )
-        
+
         let context = InboundStreamGateContext(
             connectionID: self.id,
             remotePeer: remotePeer,
@@ -761,24 +761,24 @@ extension BaseConnection {
         self.consultGater({ await gater.shouldAcceptInboundStream(context) }) { [weak self] decision in
             self?.applyInboundGateDecision(decision, on: childChannel, supporting: supported)
         }
-        
+
         return buffered
     }
-    
+
     /// Installs the multistream-select listener on an accepted inbound child channel, restricted to the
     /// protocols the gater approved, then releases the bytes the gate buffer has been holding.
     private func configureInboundUpgrader(on childChannel: Channel, protocols: [String]) -> EventLoopFuture<Void> {
         let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
-        
+
         self.logger.trace("Negotiating inbound stream over \(protocols.count) gater-approved protocol(s)")
-        
+
         let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
             protocols: protocols,
             mode: .listener,
             logger: self.logger,
             promise: negotiationPromise
         )
-        
+
         negotiationPromise.futureResult.whenComplete { [weak self] result in
             guard let self = self, self.application.isRunning else { return }
             switch result {
@@ -786,7 +786,7 @@ extension BaseConnection {
                 self.untrackStream(on: childChannel)
                 self.muxer?.removeStream(channel: childChannel)
                 self.logger.error("Error while upgrading Inbound ChildChannel: \(error)")
-                
+
             case .success(let proto):
                 // Append a stream event in our stream history array
                 self.streamHistory.append(
@@ -797,7 +797,7 @@ extension BaseConnection {
                         date: Date()
                     )
                 )
-                
+
                 // Finish the upgrade
                 self.finishUpgrading(
                     proto,
@@ -807,13 +807,13 @@ extension BaseConnection {
                 )
             }
         }
-        
+
         // MSS gets installed after the buffer so that it captures the replayed bytes upon the buffers removal
         return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last).flatMap {
             childChannel.pipeline.removeHandler(name: StreamGateBuffer.handlerName)
         }
     }
-    
+
     /// This function gets called by our Muxer when instantiating a new outbound child Channel.
     /// Take this opportunity to configure the child channel's pipeline for the specified protocol
     /// before data transmission begins.
@@ -822,16 +822,16 @@ extension BaseConnection {
         self.eventLoop.flatSubmit {
             // Cancel our idleTimeoutTask if we have one
             self.cancelTimeoutTask()
-            
+
             guard let idx = self.newStreamCache.firstIndex(where: { $0.proto == `protocol` }) else {
                 self.logger.error("No Responder For `\(`protocol`)`")
                 self.logger.error("\(self.newStreamCache)")
                 return childChannel.eventLoop.makeFailedFuture(Application.Connections.Errors.noResponder)
             }
             let pendingStream = self.newStreamCache.remove(at: idx)
-            
+
             self.trackStream(on: childChannel, direction: .outbound)
-            
+
             let negotiationPromise = childChannel.eventLoop.makePromise(of: NegotiationResult.self)
             let mssHandlers: [ChannelHandler] = self.application.upgrader.negotiate(
                 protocols: [`protocol`],
@@ -839,7 +839,7 @@ extension BaseConnection {
                 logger: self.logger,
                 promise: negotiationPromise
             )
-            
+
             // Register our post negotiation callback
             negotiationPromise.futureResult.whenComplete { [weak self] result in
                 guard let self = self, self.application.isRunning else { return }
@@ -848,7 +848,7 @@ extension BaseConnection {
                     self.untrackStream(on: childChannel)
                     self.muxer?.removeStream(channel: childChannel)
                     self.logger.error("Error while upgrading Outbound ChildChannel: \(error)")
-                    
+
                 case .success(let proto):
                     // Append a stream event in our stream history array
                     self.streamHistory.append(
@@ -859,7 +859,7 @@ extension BaseConnection {
                             date: Date()
                         )
                     )
-                    
+
                     // Finish upgrading the child channel
                     self.finishUpgrading(
                         proto,
@@ -869,12 +869,12 @@ extension BaseConnection {
                     )
                 }
             }
-            
+
             // Kick off the negotiation
             return childChannel.pipeline.addHandler(mssHandlers.first!, name: "upgrader", position: .last)
         }
     }
-    
+
     /// Install the route's handlers, record the stream, and announce it.
     private func finishUpgrading(
         _ proto: NegotiationResult,
@@ -891,7 +891,7 @@ extension BaseConnection {
             self.failPendingCaller(responder, direction: direction, with: ChannelError.ioOnClosedChannel)
             return
         }
-        
+
         // Install the responder and finalize the child channel upgrade.
         self.upgradeChildChannel(
             proto,
@@ -900,26 +900,26 @@ extension BaseConnection {
             direction: direction
         ).whenComplete { [weak self] result in
             guard let self = self, self.application.isRunning else { return }
-            
+
             // Append a stream event in our stream history array
             self.streamHistory.append(
                 StreamStateEntry(proto: proto.protocol, direction: direction, state: .open, date: Date())
             )
-            
+
             self.logger.trace("Result of Upgrader Removal and Pipeline Config: \(result)")
             self.logger.debug("🔀 New \(direction) ChildChannel[`\(proto)`] Ready!")
             self.logger.trace("List of Streams:")
             self.logger.trace(
                 "\(self.streams.map({ "\($0.protocolCodec) -> \($0.id):\($0.name ?? "NIL"):\($0.streamState)" }).joined(separator: ", "))"
             )
-            
+
             // The pipeline never finished being configured — the stream closed mid-upgrade, or the
             // muxer went away — so, as above, there's no handler on it to report the failure.
             if case .failure(let error) = result {
                 self.failPendingCaller(responder, direction: direction, with: error)
                 return
             }
-            
+
             // Post about the new stream on our application's Event Bus
             guard let str = self.streams.first(where: { $0.channel === childChannel }) as? _Stream else { return }
             str._connection.withLockedValue { $0 = self }
@@ -937,7 +937,7 @@ extension BaseConnection {
             }
         }
     }
-    
+
     /// To be called when the childChannel's protocol negotiation completes
     ///
     /// Note: Also is responsible for forwarding any leftover bytes received during the childChannel
@@ -950,7 +950,7 @@ extension BaseConnection {
     ) -> EventLoopFuture<Void> {
         //Install the protocol on the channel's pipeline...
         logger.trace("Negotiated \(proto)")
-        
+
         guard let muxer = self.muxer else {
             logger.debug("Muxer went away before `\(proto.protocol)` could be installed")
             return childChannel.eventLoop.makeFailedFuture(
@@ -964,10 +964,10 @@ extension BaseConnection {
         }
         logger.trace("Attempting to install route (`\(proto)`) specific ChannelHandlers")
         logger.trace("\(handlers.map({ String(describing: $0) }).joined(separator: ", "))")
-        
+
         // Prepare our activity monitor for the Encoder / Decoder handlers
         let activity = self.activityRecord(for: childChannel)
-        
+
         // Prepare the Responder handlers for installation
         handlers.append(
             contentsOf: [
@@ -983,9 +983,9 @@ extension BaseConnection {
                 ResponderChannelHandler(responder: responder, logger: logger),
             ] as [ChannelHandler]
         )
-        
+
         let codec = proto.protocol
-        
+
         // update our stream state
         return muxer.updateStream(channel: childChannel, state: .open, proto: codec).flatMap {
             () -> EventLoopFuture<Void> in
@@ -1012,7 +1012,7 @@ extension BaseConnection {
             }
         }
     }
-    
+
     /// Whether it's still worth touching `childChannel.pipeline`.
     private func streamIsStillOpen(_ childChannel: Channel, proto: String) -> Bool {
         guard childChannel.isActive else {
@@ -1026,12 +1026,12 @@ extension BaseConnection {
 // MARK: - Stream gating
 
 extension BaseConnection {
-    
+
     /// The protocols our application supports (the gater can return a subset of these)
     private var supportedProtocols: [String] {
         self.application.routes.all.map { $0.description }
     }
-    
+
     /// Asks the gater for a verdict and delivers it back on our event loop.
     private func consultGater<Decision: Sendable>(
         _ ask: @escaping @Sendable () async -> Decision,
@@ -1043,7 +1043,7 @@ extension BaseConnection {
             eventLoop.execute { apply(decision) }
         }
     }
-    
+
     /// Narrows our supported protocols down to what the gater approved.
     private func approvedProtocols(
         _ decision: InboundStreamGateDecision,
@@ -1061,7 +1061,7 @@ extension BaseConnection {
             return []
         }
     }
-    
+
     /// Applies the gater's verdict to an inbound stream whose bytes a ``StreamGateBuffer`` has been
     /// holding: either install mss for the approved protocols, or reset the stream having negotiated
     /// nothing at all.
@@ -1072,20 +1072,20 @@ extension BaseConnection {
         supporting supported: [String]
     ) {
         guard self.application.isRunning else { return }
-        
+
         if case .reject(let reason) = decision {
             self.logger.notice("StreamGater rejected inbound stream: \(reason)")
             self.abandonStream(on: childChannel)
             return
         }
-        
+
         let approved = self.approvedProtocols(decision, from: supported)
         guard !approved.isEmpty else {
             self.logger.notice("StreamGater left no supported protocols for this inbound stream; rejecting it")
             self.abandonStream(on: childChannel)
             return
         }
-        
+
         // approved, proceed with the upgrade using the approved protocols
         self.configureInboundUpgrader(on: childChannel, protocols: approved).whenFailure { [weak self] error in
             guard let self = self else { return }
@@ -1102,7 +1102,7 @@ extension BaseConnection {
 // MARK: - Stream pruning
 
 extension BaseConnection {
-    
+
     /// Begin tracking a child channel. Called the moment we learn of a stream, negotiated or not.
     /// - Note: Must be called on `self.eventLoop`.
     private func trackStream(
@@ -1124,17 +1124,17 @@ extension BaseConnection {
             self?.streamRecords.removeValue(forKey: key)
         }
     }
-    
+
     /// - Note: Must be called on `self.eventLoop`.
     private func untrackStream(on childChannel: Channel) {
         self.streamRecords.removeValue(forKey: ObjectIdentifier(childChannel))
     }
-    
+
     /// - Note: Must be called on `self.eventLoop`.
     private func activityRecord(for childChannel: Channel) -> StreamActivityRecord? {
         self.streamRecords[ObjectIdentifier(childChannel)]?.activity
     }
-    
+
     /// Attach the muxer's `Stream` to our record and stamp the negotiation time.
     /// - Note: Must be called on `self.eventLoop`.
     private func resolveTrackedStream(_ stream: LibP2PCore.Stream, on childChannel: Channel) {
@@ -1144,7 +1144,7 @@ extension BaseConnection {
         record.negotiatedAt = Date()
         self.streamRecords[key] = record
     }
-    
+
     /// Schedule a prune
     /// - Note: Must be called on `self.eventLoop`.
     private func armPruneSweep() {
@@ -1159,30 +1159,30 @@ extension BaseConnection {
             self?.sweepForPrunableStreams()
         }
     }
-    
+
     private func cancelPruneSweep() {
         self.pruneSweepTask?.cancel()
         self.pruneSweepTask = nil
     }
-    
+
     /// Whether a prune sweep is currently armed.
     /// - Note: `internal` only so tests can assert we neither leak nor skip the sweep.
     internal var hasPruneSweepScheduled: Bool {
         self.pruneSweepTask != nil
     }
-    
+
     /// Arms the sweep without going through a full security + muxer upgrade.
     /// - Note: `internal` only so tests can exercise the scheduling decision directly.
     internal func armPruneSweepForTesting() {
         self.armPruneSweep()
     }
-    
+
     /// One pruning pass: snapshot on the loop, decide on the actor, apply back on the loop.
     /// - Note: Must be called on `self.eventLoop`.
     private func sweepForPrunableStreams() {
         guard self.stats.status != .closing, self.stats.status != .closed else { return }
         guard !self.streamRecords.isEmpty else { return }
-        
+
         let snapshots = self.streamRecords.map { key, record in
             StreamLivenessSnapshot(
                 key: key,
@@ -1195,7 +1195,7 @@ extension BaseConnection {
                 lastActivityAt: record.activity.lastActivityAt
             )
         }
-        
+
         let pruner = self.streamPruner
         let now = Date()
         let eventLoop = self.eventLoop
@@ -1207,7 +1207,7 @@ extension BaseConnection {
             }
         }
     }
-    
+
     /// Apply the results of the pruner (closing / reseting the streams)
     /// - Note: Must be called on `self.eventLoop`.
     private func applyPruneActions(_ actions: [ObjectIdentifier: StreamPruneAction]) {
@@ -1216,11 +1216,11 @@ extension BaseConnection {
             /// deciding — so re-resolve rather than trusting the snapshot.
             guard let record = self.streamRecords.removeValue(forKey: key) else { continue }
             guard record.channel.isActive else { continue }
-            
+
             let description =
-            "Stream[\(record.stream?.id.description ?? "?")][\(record.stream?.protocolCodec ?? "unnegotiated")][\(record.direction)]"
+                "Stream[\(record.stream?.id.description ?? "?")][\(record.stream?.protocolCodec ?? "unnegotiated")][\(record.direction)]"
             self.logger.debug("Pruning \(description) (\(action))")
-            
+
             switch action {
             case .reset:
                 if let stream = record.stream {
@@ -1239,11 +1239,10 @@ extension BaseConnection {
     }
 }
 
-
 // MARK: - Connection Closing
 
 extension BaseConnection {
-    
+
     /// Called as soon as there is a request to close the Connection (internally via the connection
     /// manager, or externally via the user)
     internal func onClosing() -> EventLoopFuture<Void> {
@@ -1252,7 +1251,7 @@ extension BaseConnection {
             self.logger.trace("Closing")
         }
     }
-    
+
     public func close() -> EventLoopFuture<Void> {
         self.registry = [:]
         self.cancelTimeoutTask()
@@ -1264,7 +1263,7 @@ extension BaseConnection {
                 let timeout = self.eventLoop.scheduleTask(in: .seconds(1)) {
                     closePromise.fail(Application.Connections.Errors.failedToCloseAllStreams)
                 }
-                
+
                 closePromise.completeWith(
                     self.streams.map { $0.close(gracefully: true) }.flatten(on: self.eventLoop).flatMapAlways {
                         result -> EventLoopFuture<Void> in
@@ -1292,7 +1291,7 @@ extension BaseConnection {
                         }
                     }
                 )
-                
+
                 return closePromise.futureResult.flatMapAlways { res in
                     self.stats.status = .closed
                     switch res {
@@ -1406,7 +1405,7 @@ extension BaseConnection {
     internal enum StateTransitionError: Error {
         case invalidStateTransition
     }
-    
+
     /// Drives the state machine to `.muxed(remotePeer)` without running a real security or muxer
     /// handshake, so a test can exercise the stream paths (which need an authenticated peer to build a
     /// gate context) against a hand-installed muxer.

--- a/Sources/LibP2P/Connections/BaseConnection.swift
+++ b/Sources/LibP2P/Connections/BaseConnection.swift
@@ -503,7 +503,10 @@ extension BaseConnection {
             openStreamCount: self.muxer?.streams.count ?? 0
         )
         let gater = self.streamGater
-        self.consultGater({ await gater.shouldAllowOutboundStream(context) }) { [weak self] decision in
+        let ask: (@Sendable () async -> OutboundStreamGateDecision) = {
+            await gater.shouldAllowOutboundStream(context)
+        }
+        self.consultGater(ask) { [weak self] decision in
             guard let self = self else { return }
 
             if case .reject(let reason) = decision {
@@ -758,7 +761,10 @@ extension BaseConnection {
             openStreamCount: self.muxer?.streams.count ?? 0
         )
         let gater = self.streamGater
-        self.consultGater({ await gater.shouldAcceptInboundStream(context) }) { [weak self] decision in
+        let ask: (@Sendable () async -> InboundStreamGateDecision) = {
+            await gater.shouldAcceptInboundStream(context)
+        }
+        self.consultGater(ask) { [weak self] decision in
             self?.applyInboundGateDecision(decision, on: childChannel, supporting: supported)
         }
 

--- a/Sources/LibP2P/Connections/ChannelHandlers/StreamGateBuffer.swift
+++ b/Sources/LibP2P/Connections/ChannelHandlers/StreamGateBuffer.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2026 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+
+/// A passive buffer installed on a fresh inbound child channel while its ``StreamGater`` verdict is
+/// outstanding.
+///
+/// The muxed child-channel initializer has to resolve within its own event-loop tick — YAMUX only sends
+/// its open-confirmation once that future completes, and treats any frame that lands while the stream is
+/// still `.requestedRemotely` as a protocol violation. So we can't suspend there waiting on the gater.
+///
+/// Instead this goes on the pipeline synchronously, in place of multistream-select, and holds whatever
+/// the remote pipelines behind its stream-open. Once the verdict lands the connection either installs the
+/// mss upgrader (for the approved protocols) behind this handler and removes it, replaying the held
+/// bytes into the upgrader, or resets the stream, discarding the buffered bytes.
+internal final class StreamGateBuffer: ChannelInboundHandler, RemovableChannelHandler {
+    public typealias InboundIn = ByteBuffer
+    public typealias InboundOut = ByteBuffer
+
+    /// The name this handler is installed under, so the connection can remove it.
+    internal static let handlerName = "streamGate"
+
+    /// Bytes received while gating, held until we're removed
+    private var buffer: ByteBuffer?
+
+    private let logger: Logger
+
+    init(logger: Logger) {
+        var logger = logger
+        logger[metadataKey: "StreamGateBuffer"] = .string("buffering")
+        self.logger = logger
+    }
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        // Buffer everything
+        var incoming = unwrapInboundIn(data)
+        if buffer == nil {
+            buffer = incoming
+        } else {
+            buffer!.writeBuffer(&incoming)
+        }
+    }
+
+    public func channelReadComplete(context: ChannelHandlerContext) {
+        // Absorb read-complete's while gating; we'll fire one when we flush on removal.
+    }
+
+    public func handlerRemoved(context: ChannelHandlerContext) {
+        // Replay anything we buffered while the gater was deciding
+        if let buffer, buffer.readableBytes > 0 {
+            self.logger.trace("Forwarding \(buffer.readableBytes) buffered pre-negotiation byte(s)")
+            context.fireChannelRead(wrapInboundOut(buffer))
+            context.fireChannelReadComplete()
+        }
+        self.buffer = nil
+    }
+}

--- a/Sources/LibP2P/Connections/Gating/StreamGater.swift
+++ b/Sources/LibP2P/Connections/Gating/StreamGater.swift
@@ -14,10 +14,11 @@
 
 import LibP2PCore
 
-/// The verdict a `StreamGater` returns for a stream it was asked about.
-enum StreamGateDecision: Sendable {
+/// The verdict a `StreamGater` returns for an outbound stream it was asked about.
+enum OutboundStreamGateDecision: Sendable {
+    /// Accept the outbound stream for the designated protocol
     case accept
-    /// Reject the stream. The reason is logged and, for a rejected inbound stream, surfaced as the
+    /// Reject the stream. The reason is logged and, for a rejected outbound stream, surfaced as the
     /// error that closes the child channel.
     case reject(reason: String)
 
@@ -27,24 +28,45 @@ enum StreamGateDecision: Sendable {
     }
 }
 
+/// The verdict a `StreamGater` returns for an inbound stream it was asked about.
+enum InboundStreamGateDecision: Sendable {
+    /// Accept the inbound stream for all of our supported protocols
+    case accept
+    /// Accept the inbound stream for only a subset of protocols
+    ///
+    /// - Note: The subset is intersected with the protocols we actually support, so listing a protocol we
+    /// have no route for is a no-op. An empty intersection is treated as a rejection.
+    case acceptFor(protocols: [String])
+    /// Reject the stream. The reason is logged and, for a rejected inbound stream, surfaced as the
+    /// error that closes the child channel.
+    case reject(reason: String)
+
+    var isAccepted: Bool {
+        switch self {
+        case .accept: return true
+        case .acceptFor(let protocols): return !protocols.isEmpty
+        case .reject: return false
+        }
+    }
+}
+
 /// What we know about an inbound stream before multistream-select has picked a protocol.
 struct InboundStreamGateContext: Sendable {
     let connectionID: UUID
-    let remotePeer: PeerID?
-    let remoteAddress: Multiaddr?
+    let remotePeer: PeerID
+    let remoteAddress: Multiaddr
+    let supportedProtocols: [String]
     /// The number of streams the muxer currently has open on this connection.
     ///
     /// - Note: This includes the stream being gated
     let openStreamCount: Int
 }
 
-/// What we know about a stream once multistream-select has agreed on a protocol, but before the
-/// route's handlers are installed on its pipeline.
-struct NegotiatedStreamGateContext: Sendable {
+/// What we know about the proposed outbound stream
+struct OutboundStreamGateContext: Sendable {
     let connectionID: UUID
-    let remotePeer: PeerID?
-    let remoteAddress: Multiaddr?
-    let direction: ConnectionStats.Direction
+    let remotePeer: PeerID
+    let remoteAddress: Multiaddr
     let protocolCodec: String
     let openStreamCount: Int
 }
@@ -53,24 +75,31 @@ struct NegotiatedStreamGateContext: Sendable {
 ///
 /// - Note: Should move to `swift-libp2p-core` once the shape settles.
 protocol StreamGater: Sendable {
-    /// Called as soon as the remote opens an inbound stream, before any protocol is known.
+    /// Called as soon as the remote opens an inbound stream
     ///
-    /// This runs concurrently with the connection installing the stream's multistream-select
-    /// upgrader. A `.reject` will tear down the stream before a ResposeHandler is installed. But
-    /// not necessarily before negotiation bytes have been exchanged.
-    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision
+    /// - This call blocks the inbound stream from being configured, so keep it quick / lite.
+    /// - This call is passed the current list of supported protocols, of which a subset can be passed back to
+    /// constrict / constrain what protocols will be negotiated.
+    ///
+    /// - Note: MSS negotiation takes place on `.accept` and `.acceptFor`, the stream is reset on `.reject`.
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision
 
-    /// Called on every stream — inbound and outbound — once its protocol has been negotiated and
-    /// before the route's handlers are installed.
-    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision
+    /// Called right before we open an outbound stream
+    ///
+    /// Use this method to prevent speaking certain protocols with certain peers.
+    /// Like if there's a certain peer that you never want to `ping/1.0.0` you could define that rule here.
+    ///
+    /// - Note: Consulted before the muxer is asked for a child channel, so a `.reject` costs nothing on
+    ///   the wire. The reason is handed back to the caller's `Responder` as an `.error` event.
+    func shouldAllowOutboundStream(_ context: OutboundStreamGateContext) async -> OutboundStreamGateDecision
 }
 
 extension StreamGater {
-    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision {
         .accept
     }
 
-    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision {
+    func shouldAllowOutboundStream(_ context: OutboundStreamGateContext) async -> OutboundStreamGateDecision {
         .accept
     }
 }

--- a/Sources/LibP2PTestUtils/Mocks.swift
+++ b/Sources/LibP2PTestUtils/Mocks.swift
@@ -104,17 +104,29 @@ public final class MockMuxer: Muxer, @unchecked Sendable {
     }
 
     /// Injects an already-open stream directly into the muxer (bypassing negotiation), for exercising the
-    /// connection's stream-teardown logic. The stream shares `loop` so `close()` chaining resolves under a
-    /// single `EmbeddedEventLoop.run()`.
+    /// connection's stream-teardown logic. The stream shares `loop` with the connection, so the two
+    /// `close()` chains resolve together under a single drain of that loop.
     @discardableResult
-    public func openStreamForTest(proto: String, loop: EmbeddedEventLoop) -> MockStream {
+    public func openStreamForTest(proto: String, loop: EventLoop) -> MockStream {
         self.makeStream(proto: proto, loop: loop)
     }
 
     private func makeStream(proto: String, loop: EventLoop) -> MockStream {
-        let embeddedLoop = (loop as? EmbeddedEventLoop) ?? EmbeddedEventLoop()
+        // Match the child channel to the loop it has to run on. `EmbeddedChannel` may only be driven from
+        // the thread that created its `EmbeddedEventLoop`, whereas `NIOAsyncTestingChannel` is safe to use
+        // from an `async` test that hops threads across `await`s.
+        let channel: Channel
+        switch loop {
+        case let loop as NIOAsyncTestingEventLoop:
+            channel = NIOAsyncTestingChannel(loop: loop)
+        case let loop as EmbeddedEventLoop:
+            channel = EmbeddedChannel(loop: loop)
+        default:
+            channel = EmbeddedChannel()
+        }
+
         let stream = MockStream(
-            channel: EmbeddedChannel(loop: embeddedLoop),
+            channel: channel,
             mode: .initiator,
             id: self.nextID,
             name: "\(self.nextID)",

--- a/Tests/LibP2PTests/ConnectionLifecycleTests.swift
+++ b/Tests/LibP2PTests/ConnectionLifecycleTests.swift
@@ -123,8 +123,8 @@ extension LibP2PTests {
         @Test("Closing a connection closes its open sub-streams")
         func testConnectionClosesItsSubStreams() async throws {
             try await withApp { app in
-                let loop = EmbeddedEventLoop()
-                let channel = EmbeddedChannel(loop: loop)
+                let channel = NIOAsyncTestingChannel()
+                let loop = channel.testingEventLoop
 
                 let connection = BaseConnection(
                     application: app,
@@ -142,9 +142,9 @@ extension LibP2PTests {
                 #expect(connection.streams.count == 1)
                 #expect(stream.streamState == .open)
 
-                let closeFuture: EventLoopFuture<Void> = connection.close()
-                loop.run()
-                try await closeFuture.get()
+                // A `NIOAsyncTestingEventLoop` drains itself whenever work is submitted from off the
+                // loop, so the whole close chain resolves without a manual `run()`.
+                try await connection.close().get()
 
                 #expect(connection.streams.count == 0)
                 #expect(stream.streamState == .closed)
@@ -158,8 +158,7 @@ extension LibP2PTests {
         @Test("close() marks the connection closed")
         func testCloseMarksStatusClosed() async throws {
             try await withApp { app in
-                let loop = EmbeddedEventLoop()
-                let channel = EmbeddedChannel(loop: loop)
+                let channel = NIOAsyncTestingChannel()
 
                 let connection = BaseConnection(
                     application: app,
@@ -169,9 +168,7 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
 
-                let closeFuture: EventLoopFuture<Void> = connection.close()
-                loop.run()
-                try await closeFuture.get()
+                try await connection.close().get()
 
                 #expect(connection.status == .closed)
             }

--- a/Tests/LibP2PTests/StreamGaterTests.swift
+++ b/Tests/LibP2PTests/StreamGaterTests.swift
@@ -27,39 +27,19 @@ extension LibP2PTests {
     @Suite("StreamGaterTests")
     struct StreamGaterTests {
 
-        /// A gater that rejects an inbound stream must tear it down.
-        ///
-        /// The initializer future itself still *succeeds* — it has to, since it gates child-channel
-        /// activation and YAMUX reports a protocol violation for frames arriving before that. The
-        /// rejection lands separately, as soon as the gater answers, and shows up as the muxer being
-        /// asked to drop the child channel.
-        @Test("A rejected inbound stream is dropped from the muxer once the verdict lands")
+        @Test("A rejected inbound stream is torn down without ever negotiating")
         func testRejectedInboundStreamIsTornDown() async throws {
             try await withApp { app in
                 let loop = NIOAsyncTestingEventLoop()
                 let channel = NIOAsyncTestingChannel(loop: loop)
                 let child = NIOAsyncTestingChannel(loop: loop)
-                let gater = RecordingStreamGater(decision: .reject(reason: "not today"))
+                let gater = RecordingStreamGater(inbound: .reject(reason: "not today"))
                 let muxer = RecordingMuxer(eventLoop: loop)
 
-                let connection = BaseConnection(
-                    application: app,
-                    channel: channel,
-                    direction: .inbound,
-                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
-                    expectedRemotePeer: nil,
-                    streamGater: gater,
-                    streamPruner: NoOpStreamPruner()
-                )
-                connection.muxer = muxer
-                connection.isMuxed = true
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
 
-                // The initializer's own outcome is deliberately not asserted here: the rejection can
-                // land first and close the child channel, which makes the in-flight `addHandler` fail
-                // with `.ioOnClosedChannel`. Either ordering is correct — the stream is going away.
-                // (`testASlowGaterDoesNotBlockTheInitializer` covers the non-blocking property.)
                 let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
-                initialized.whenComplete { _ in }
+                try await driving(loop) { try await initialized.get() }
 
                 // The verdict arrives via `eventLoop.execute` from a `Task`, so drive the loop while we
                 // poll. `NIOAsyncTestingEventLoop` is thread-safe, unlike `EmbeddedEventLoop`.
@@ -69,51 +49,43 @@ extension LibP2PTests {
                 #expect(droppedIt)
 
                 #expect(await gater.inboundCallCount == 1)
-                // The gater never saw a protocol — the stream was gone before it negotiated one.
-                #expect(await gater.negotiatedCallCount == 0)
+                // Nothing was ever offered to the remote.
+                #expect(try await Self.hasHandler(named: "upgrader", on: child, driving: loop) == false)
 
                 _ = try? await channel.finish()
                 _ = muxer
             }
         }
 
-        /// The default `AllowAllStreamGater` must not change the behaviour of the connections
-        /// `BaseConnection` replaces: an accepted inbound stream proceeds to install its upgrader, and the
-        /// muxer is left alone.
         @Test("An accepted inbound stream proceeds to protocol negotiation")
         func testAcceptedInboundStreamInstallsUpgrader() async throws {
             try await withApp { app in
                 let loop = NIOAsyncTestingEventLoop()
                 let channel = NIOAsyncTestingChannel(loop: loop)
                 let child = NIOAsyncTestingChannel(loop: loop)
-                let gater = RecordingStreamGater(decision: .accept)
+                let gater = RecordingStreamGater(inbound: .accept)
                 let muxer = RecordingMuxer(eventLoop: loop)
 
-                let connection = BaseConnection(
-                    application: app,
-                    channel: channel,
-                    direction: .inbound,
-                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
-                    expectedRemotePeer: nil,
-                    streamGater: gater,
-                    streamPruner: NoOpStreamPruner()
-                )
-                connection.muxer = muxer
-                connection.isMuxed = true
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
 
                 let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
                 try await driving(loop) { try await initialized.get() }
 
+                // multistream-select lands once the verdict does, not before.
+                let negotiating = try await driving(loop) {
+                    await waitUntilTrue {
+                        (try? await Self.hasHandler(named: "upgrader", on: child, driving: loop)) == true
+                    }
+                }
+                #expect(negotiating)
+
                 #expect(await gater.inboundCallCount == 1)
                 // Accepted, so nothing was torn down...
                 #expect(muxer.removedChannelCount == 0)
-                // ...and multistream-select is now on the child channel's pipeline, waiting to negotiate.
-                // Collapse the lookup to a `Bool` on the event loop: `ChannelHandlerContext` isn't
-                // `Sendable`, so it must not cross the await boundary.
-                let hasUpgrader = try await driving(loop) {
-                    try await child.pipeline.context(name: "upgrader").map { _ in true }.get()
-                }
-                #expect(hasUpgrader)
+                // ...and the gate buffer stepped aside for the upgrader.
+                #expect(
+                    try await Self.hasHandler(named: StreamGateBuffer.handlerName, on: child, driving: loop) == false
+                )
 
                 _ = try? await channel.finish()
                 _ = muxer
@@ -122,9 +94,8 @@ extension LibP2PTests {
 
         /// YAMUX only sends its open-confirmation (moving the stream out of `.requestedRemotely`) once
         /// this future resolves, and treats any frame arriving before that as
-        /// `YAMUX.Error.protocolViolation` — so a peer that pipelines its payload behind the stream-open
-        /// breaks the stream if we suspend here. An earlier revision awaited the gater and produced
-        /// exactly that error, across every YAMUX integration test.
+        /// `YAMUX.Error.protocolViolation`, so a peer that pipelines its payload behind the stream open
+        /// breaks the stream if we suspend here.
         @Test("A slow gater does not block the child-channel initializer")
         func testASlowGaterDoesNotBlockTheInitializer() async throws {
             try await withApp { app in
@@ -134,25 +105,152 @@ extension LibP2PTests {
                 let gater = SlowStreamGater(delay: .milliseconds(500))
                 let muxer = RecordingMuxer(eventLoop: loop)
 
-                let connection = BaseConnection(
-                    application: app,
-                    channel: channel,
-                    direction: .inbound,
-                    remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
-                    expectedRemotePeer: nil,
-                    streamGater: gater,
-                    streamPruner: NoOpStreamPruner()
-                )
-                connection.muxer = muxer
-                connection.isMuxed = true
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
 
                 let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
                 try await driving(loop) { try await initialized.get() }
 
                 // The initializer resolved; the gater hasn't even answered yet.
                 #expect(await gater.hasAnswered == false)
-                // And the stream is still alive.
+                // And the stream is still alive...
                 #expect(muxer.removedChannelCount == 0)
+                // ...holding its bytes behind the gate buffer, with nothing negotiated yet.
+                #expect(try await Self.hasHandler(named: StreamGateBuffer.handlerName, on: child, driving: loop))
+                #expect(try await Self.hasHandler(named: "upgrader", on: child, driving: loop) == false)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("The inbound gater is handed the protocols we actually support")
+        func testInboundGaterIsHandedOurSupportedProtocols() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(inbound: .accept)
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
+
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                try await driving(loop) { try await initialized.get() }
+                _ = try await driving(loop) { await waitUntilTrue { await gater.inboundCallCount == 1 } }
+
+                #expect(await gater.offeredProtocols == app.routes.all.map { $0.description })
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("acceptFor with no protocols we support is a rejection")
+        func testAcceptForUnsupportedProtocolsRejects() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(inbound: .acceptFor(protocols: ["/not/a/route/1.0.0"]))
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
+
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                try await driving(loop) { try await initialized.get() }
+
+                let droppedIt = try await driving(loop) {
+                    await waitUntilTrue { muxer.wasAskedToRemove(child) }
+                }
+                #expect(droppedIt)
+                #expect(try await Self.hasHandler(named: "upgrader", on: child, driving: loop) == false)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("acceptFor with a supported subset proceeds to negotiation")
+        func testAcceptForSupportedSubsetProceeds() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let child = NIOAsyncTestingChannel(loop: loop)
+                let allowed = try #require(app.routes.all.map { $0.description }.first)
+                let gater = RecordingStreamGater(inbound: .acceptFor(protocols: [allowed]))
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
+
+                let initialized: EventLoopFuture<Void> = connection.inboundMuxedChildChannelInitializer(child)
+                try await driving(loop) { try await initialized.get() }
+
+                let negotiating = try await driving(loop) {
+                    await waitUntilTrue {
+                        (try? await Self.hasHandler(named: "upgrader", on: child, driving: loop)) == true
+                    }
+                }
+                #expect(negotiating)
+                #expect(muxer.removedChannelCount == 0)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("A rejected outbound stream never reaches the muxer and fails its caller")
+        func testRejectedOutboundStreamNeverReachesTheMuxer() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(inbound: .accept, outbound: .reject(reason: "never this peer"))
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
+
+                let reported = NIOLockedValueBox<[String]>([])
+                connection.newStream(forProtocol: "/echo/1.0.0") { req in
+                    if case .error(let error) = req.event {
+                        reported.withLockedValue { $0.append("\(error)") }
+                    }
+                    return req.eventLoop.makeSucceededFuture(RawResponse(payload: ByteBuffer()))
+                }
+
+                let failed = try await driving(loop) {
+                    await waitUntilTrue { !reported.withLockedValue { $0 }.isEmpty }
+                }
+                #expect(failed)
+                #expect(reported.withLockedValue { $0 }.first?.contains("never this peer") == true)
+
+                #expect(await gater.outboundCallCount == 1)
+                #expect(await gater.outboundProtocols == ["/echo/1.0.0"])
+                // The muxer was never troubled for a stream we weren't allowed to open.
+                #expect(muxer.newStreamCallCount == 0)
+
+                _ = try? await channel.finish()
+                _ = muxer
+            }
+        }
+
+        @Test("An approved outbound stream is handed to the muxer")
+        func testApprovedOutboundStreamReachesTheMuxer() async throws {
+            try await withApp { app in
+                let loop = NIOAsyncTestingEventLoop()
+                let channel = NIOAsyncTestingChannel(loop: loop)
+                let gater = RecordingStreamGater(inbound: .accept, outbound: .accept)
+                let muxer = RecordingMuxer(eventLoop: loop)
+
+                let connection = try Self.muxedConnection(app: app, channel: channel, gater: gater, muxer: muxer)
+
+                connection.newStream(forProtocol: "/echo/1.0.0") { req in
+                    req.eventLoop.makeSucceededFuture(RawResponse(payload: ByteBuffer()))
+                }
+
+                let asked = try await driving(loop) {
+                    await waitUntilTrue { muxer.newStreamCallCount == 1 }
+                }
+                #expect(asked)
+                #expect(muxer.requestedProtocols == ["/echo/1.0.0"])
 
                 _ = try? await channel.finish()
                 _ = muxer
@@ -162,7 +260,7 @@ extension LibP2PTests {
         @Test("The AppConnection initializer picks up the app's configured gater")
         func testConnectionResolvesGaterFromApplication() async throws {
             try await withApp { app in
-                let gater = RecordingStreamGater(decision: .reject(reason: "configured"))
+                let gater = RecordingStreamGater(inbound: .reject(reason: "configured"))
                 app.connectionManager.use(streamGater: gater)
                 app.connectionManager.use(streamPruner: NoOpStreamPruner())
                 app.connectionManager.use(connectionType: BaseConnection.self)
@@ -180,13 +278,14 @@ extension LibP2PTests {
                     expectedRemotePeer: nil
                 )
                 let base = try #require(connection as? BaseConnection)
+                try base.markSecuredForTesting(remotePeer: try PeerID(.Ed25519))
                 base.muxer = muxer
                 base.isMuxed = true
 
                 // Observe the resolved gater the only way an outside caller can: drive a stream past it
                 // and watch the (rejecting) verdict tear the stream down.
                 let initialized: EventLoopFuture<Void> = base.inboundMuxedChildChannelInitializer(child)
-                initialized.whenComplete { _ in }
+                try await driving(loop) { try await initialized.get() }
                 let droppedIt = try await driving(loop) {
                     await waitUntilTrue { muxer.wasAskedToRemove(child) }
                 }
@@ -199,6 +298,44 @@ extension LibP2PTests {
         }
 
         // MARK: - Helpers
+
+        /// A `BaseConnection` standing where a real one would be after its security and muxer upgrades:
+        /// an authenticated peer (which the gate contexts require) and an installed muxer.
+        private static func muxedConnection(
+            app: Application,
+            channel: Channel,
+            gater: StreamGater,
+            muxer: Muxer,
+            remoteAddress: String = "/ip4/127.0.0.1/tcp/1234"
+        ) throws -> BaseConnection {
+            let connection = BaseConnection(
+                application: app,
+                channel: channel,
+                direction: .inbound,
+                remoteAddress: try Multiaddr(remoteAddress),
+                expectedRemotePeer: nil,
+                streamGater: gater,
+                streamPruner: NoOpStreamPruner()
+            )
+            try connection.markSecuredForTesting(remotePeer: try PeerID(.Ed25519))
+            connection.muxer = muxer
+            connection.isMuxed = true
+            return connection
+        }
+
+        /// Collapses a pipeline lookup to a `Bool` on the event loop: `ChannelHandlerContext` isn't
+        /// `Sendable`, so it must not cross an await boundary.
+        private static func hasHandler(
+            named name: String,
+            on channel: Channel,
+            driving loop: NIOAsyncTestingEventLoop
+        ) async throws -> Bool {
+            let found = channel.eventLoop.submit {
+                (try? channel.pipeline.syncOperations.context(name: name)) != nil
+            }
+            await loop.run()
+            return try await found.get()
+        }
 
         /// Runs `loop` in the background while awaiting `body`.
         ///
@@ -224,39 +361,47 @@ extension LibP2PTests {
         private func waitUntilTrue(
             attempts: Int = 200,
             every: Duration = .milliseconds(5),
-            _ predicate: () -> Bool
+            _ predicate: () async -> Bool
         ) async -> Bool {
             for _ in 0..<attempts {
-                if predicate() { return true }
+                if await predicate() { return true }
                 try? await Task.sleep(for: every)
             }
-            return predicate()
+            return await predicate()
         }
     }
 }
 
 // MARK: - Test doubles
 
-/// A `StreamGater` that returns a fixed verdict and records how often, and about what, it was asked.
+/// A `StreamGater` that returns fixed verdicts and records how often, and about what, it was asked.
 actor RecordingStreamGater: StreamGater {
-    private let decision: StreamGateDecision
+    private let inboundDecision: InboundStreamGateDecision
+    private let outboundDecision: OutboundStreamGateDecision
     private(set) var inboundCallCount = 0
-    private(set) var negotiatedCallCount = 0
-    private(set) var negotiatedProtocols: [String] = []
+    private(set) var outboundCallCount = 0
+    /// The protocols we were told the connection supports, from the most recent inbound question.
+    private(set) var offeredProtocols: [String] = []
+    private(set) var outboundProtocols: [String] = []
 
-    init(decision: StreamGateDecision) {
-        self.decision = decision
+    init(
+        inbound: InboundStreamGateDecision = .accept,
+        outbound: OutboundStreamGateDecision = .accept
+    ) {
+        self.inboundDecision = inbound
+        self.outboundDecision = outbound
     }
 
-    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision {
         self.inboundCallCount += 1
-        return self.decision
+        self.offeredProtocols = context.supportedProtocols
+        return self.inboundDecision
     }
 
-    func shouldAcceptNegotiatedStream(_ context: NegotiatedStreamGateContext) async -> StreamGateDecision {
-        self.negotiatedCallCount += 1
-        self.negotiatedProtocols.append(context.protocolCodec)
-        return self.decision
+    func shouldAllowOutboundStream(_ context: OutboundStreamGateContext) async -> OutboundStreamGateDecision {
+        self.outboundCallCount += 1
+        self.outboundProtocols.append(context.protocolCodec)
+        return self.outboundDecision
     }
 }
 
@@ -270,14 +415,14 @@ actor SlowStreamGater: StreamGater {
         self.delay = delay
     }
 
-    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> StreamGateDecision {
+    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision {
         try? await Task.sleep(for: self.delay)
         self.hasAnswered = true
         return .accept
     }
 }
 
-/// A `Muxer` that holds no streams and only records the channels it was asked to drop.
+/// A `Muxer` that holds no streams and only records what it was asked to do.
 ///
 /// `MockMuxer` can't serve here: it only removes streams it minted itself, so it can't observe a
 /// `removeStream(channel:)` for a child channel the connection created.
@@ -290,9 +435,14 @@ final class RecordingMuxer: Muxer, @unchecked Sendable {
 
     private let eventLoop: EventLoop
     private let removedChannels = NIOLockedValueBox<[ObjectIdentifier]>([])
+    private let newStreamRequests = NIOLockedValueBox<[String]>([])
 
     /// How many channels this muxer was asked to drop.
     var removedChannelCount: Int { self.removedChannels.withLockedValue { $0.count } }
+
+    /// How many times this muxer was asked to open an outbound stream, and for what.
+    var newStreamCallCount: Int { self.newStreamRequests.withLockedValue { $0.count } }
+    var requestedProtocols: [String] { self.newStreamRequests.withLockedValue { $0 } }
 
     func wasAskedToRemove(_ channel: Channel) -> Bool {
         self.removedChannels.withLockedValue { $0.contains(ObjectIdentifier(channel)) }
@@ -305,7 +455,8 @@ final class RecordingMuxer: Muxer, @unchecked Sendable {
     var streams: [LibP2PCore.Stream] { [] }
 
     func newStream(channel: Channel, proto: String) throws -> EventLoopFuture<_Stream> {
-        self.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
+        self.newStreamRequests.withLockedValue { $0.append(proto) }
+        return self.eventLoop.makeFailedFuture(Application.Connections.Errors.notImplementedYet)
     }
 
     func openStream(_ stream: inout LibP2PCore.Stream) throws -> EventLoopFuture<Void> {

--- a/Tests/LibP2PTests/StreamPrunerTests.swift
+++ b/Tests/LibP2PTests/StreamPrunerTests.swift
@@ -16,6 +16,7 @@ import Foundation
 import LibP2PCore
 import LibP2PTesting
 import NIOCore
+import NIOEmbedded
 import Testing
 
 @testable import LibP2P
@@ -262,11 +263,11 @@ extension LibP2PTests {
         @Test("A NoOp pruner leaves no sweep scheduled, an idle-timeout pruner arms one")
         func testSweepIsScheduledOnlyWhenThePrunerWantsIt() async throws {
             try await withApp { app in
-                let loop = EmbeddedEventLoop()
+                let loop = NIOAsyncTestingEventLoop()
 
                 let quiet = BaseConnection(
                     application: app,
-                    channel: EmbeddedChannel(loop: loop),
+                    channel: NIOAsyncTestingChannel(loop: loop),
                     direction: .outbound,
                     remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1234"),
                     expectedRemotePeer: nil,
@@ -278,7 +279,7 @@ extension LibP2PTests {
 
                 let sweeping = BaseConnection(
                     application: app,
-                    channel: EmbeddedChannel(loop: loop),
+                    channel: NIOAsyncTestingChannel(loop: loop),
                     direction: .outbound,
                     remoteAddress: try Multiaddr("/ip4/127.0.0.1/tcp/1235"),
                     expectedRemotePeer: nil,
@@ -289,10 +290,10 @@ extension LibP2PTests {
                 #expect(sweeping.hasPruneSweepScheduled == true)
 
                 // Closing must take the sweep down with it, so nothing we scheduled outlives us.
-                let closed: EventLoopFuture<Void> = sweeping.close()
-                loop.run()
-                try await closed.get()
+                try await sweeping.close().get()
                 #expect(sweeping.hasPruneSweepScheduled == false)
+                try await quiet.close().get()
+                #expect(quiet.hasPruneSweepScheduled == false)
             }
         }
 


### PR DESCRIPTION
### What?
This PR re-defines the `StreamGater` protocol and updates the BaseConnection (and tests) to reflect the change.

### Changes:
- https://github.com/swift-libp2p/swift-libp2p/pull/73 introduced the `StreamGater` protocol and after sleeping on it I realized there's almost no good reason to close a stream after it's been negotiated. 
- So the new protocol is as follows...
```swift
protocol StreamGater: Sendable {
    /// Called as soon as the remote opens an inbound stream
    ///
    /// - This call blocks the inbound stream from being configured, so keep it quick / lite.
    /// - This call is passed the current list of supported protocols, of which a subset can be passed back to
    /// constrict / constrain what protocols will be negotiated.
    ///
    /// - Note: MSS negotiation takes place on `.accept` and `.acceptFor`, the stream is reset on `.reject`.
    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision

    /// Called right before we open an outbound stream
    ///
    /// - Use this method to prevent speaking certain protocols with certain peers.
    /// - Ex: if there's a certain peer that you never want to `ping/1.0.0` you could define that rule here.
    ///
    /// - Note: Consulted before the muxer is asked for a child channel, so a `.reject` costs nothing on
    ///   the wire. The reason is handed back to the caller's `Responder` as an `.error` event.
    func shouldAllowOutboundStream(_ context: OutboundStreamGateContext) async -> OutboundStreamGateDecision
}
```
- Both of these gates occur BEFORE any MSS negotiations takes place
    - For inbound streams you can flat our accept / reject or you can return a subset of protocols that you're willing to accept
    - For outbound streams is a simple accept / reject decision 

An example implementation of a `StreamGater` that blocks all inbound and outbound pings to a certain peer, but allows all other traffic through...
```swift
actor NoPingsForACertainPeer: StreamGater {
    private let peer: PeerID

    init(peer: PeerID) {
        self.peerID = peerID
    }

    func shouldAcceptInboundStream(_ context: InboundStreamGateContext) async -> InboundStreamGateDecision {
        if context.remotePeer == peer {
            // filter out the ping protocol, keeping the rest
            return .acceptFor(
                protocols: context.supportedProtocols.filter({ $0 != "ping/1.0.0" })
            )
        }
        return .accept
    }

    func shouldAllowOutboundStream(_ context: OutboundStreamGateContext) async -> OutboundStreamGateDecision {
        if context.remotePeer == peer && context.protocol == "ping/1.0.0" {
            return .reject
        }
        return .accept
    }
}
```
