### PR TITLE
Application Resolvers

### DIFF
--- a/Sources/LibP2P/Connections/Application+Connections+Methods.swift
+++ b/Sources/LibP2P/Connections/Application+Connections+Methods.swift
@@ -97,7 +97,7 @@ extension Application {
                 }
             }
         }.flatten(on: on).map {
-            promise.succeed(dialableAddresses.withLockedValue({$0}))
+            promise.succeed(dialableAddresses.withLockedValue({ $0 }))
         }
 
         return promise.futureResult

--- a/Sources/LibP2P/Connections/Application+Connections+Methods.swift
+++ b/Sources/LibP2P/Connections/Application+Connections+Methods.swift
@@ -74,19 +74,30 @@ extension Application {
         on: EventLoop
     ) -> EventLoopFuture<[Multiaddr]> {
         let promise = on.makePromise(of: [Multiaddr].self)
-        var dialableAddresses: [Multiaddr] = []
+        let dialableAddresses: NIOLockedValueBox<[Multiaddr]> = .init([])
 
         let _ = Set(mas).map { ma in
             self.transports.canDial(ma, on: on).map { canDial in
+                // TCP will pick up dns, dns4 and dns6 along with ip4 and ip6 addresses
                 if canDial {
                     if externalAddressesOnly {
                         guard !ma.isInternalAddress else { return }
                     }
-                    dialableAddresses.append(ma)
+                    dialableAddresses.withLockedValue({
+                        $0.append(ma)
+                    })
+                } else {
+                    // Otherwise, ask our registered resolvers if they can resolve the address
+                    // ex: dnsaddr/ will pass when the LibP2PDNSAddr package is registered
+                    if self.resolvers.can(resolve: ma) {
+                        dialableAddresses.withLockedValue({
+                            $0.append(ma)
+                        })
+                    }
                 }
             }
         }.flatten(on: on).map {
-            promise.succeed(dialableAddresses)
+            promise.succeed(dialableAddresses.withLockedValue({$0}))
         }
 
         return promise.futureResult

--- a/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
+++ b/Sources/LibP2P/Peerstore/DefaultPeerstore.swift
@@ -46,7 +46,7 @@ extension Array where Element == UInt8 {
 /// - PeerID with metadata (as we communicate with the peer) (latency, software, lib version, via Identify protocol and others)
 internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
 
-    /// Dictionary where Key == B58 PeerID String, and Value == PeerInfo that contains the PeerID and assocaited Multiaddr...
+    /// Dictionary where Key == B58 PeerID String, and Value == ComprehensivePeer that contains the PeerID and assocaited Multiaddr...
     private var store: [String: ComprehensivePeer]
 
     /// All access / manipulation of store happens on our EventLoop in order to ensure thread safety
@@ -270,7 +270,7 @@ internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
 
     /// - MARK: Address Book
 
-    /// Adds a Multiaddr to an existing PeerID
+    /// Adds a `Multiaddr` to an existing `PeerID`
     func add(address: Multiaddr, toPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<Void> {
         getPeer(withID: peer.b58String).map { compPeer in
             if let pid = try? address.getPeerID() { guard pid == peer else { return } }
@@ -278,6 +278,7 @@ internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Adds a set of `Multiaddr`s to an existing `PeerID`
     func add(addresses: [Multiaddr], toPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<Void> {
         guard !addresses.isEmpty else { return on?.makeSucceededVoidFuture() ?? eventLoop.makeSucceededVoidFuture() }
         return getPeer(withID: peer.b58String).map { compPeer in
@@ -288,25 +289,28 @@ internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
         }.hop(to: on ?? eventLoop)
     }
 
-    /// Removes a Multiaddr from an existing PeerID
+    /// Removes a `Multiaddr` from an existing `PeerID`
     func remove(address: Multiaddr, fromPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<Void> {
         getPeer(withID: peer.b58String).map { compPeer in
             compPeer.addresses.remove(address)
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Removes all `Multiaddr`s associated with the `PeerID`
     func removeAllAddresses(forPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<Void> {
         getPeer(withID: peer.b58String).map { compPeer in
             compPeer.addresses.removeAll()
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Returns all `Multiaddr`s associated with the `PeerID`
     func getAddresses(forPeer peer: PeerID, on: EventLoop? = nil) -> EventLoopFuture<[Multiaddr]> {
         getPeer(withID: peer.b58String).map { compPeer in
             Array(compPeer.addresses)
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Returns the `key` that this Peer is indexed by in the `PeerStore`
     func getPeer(byAddress address: Multiaddr, on: EventLoop? = nil) -> EventLoopFuture<String> {
         eventLoop.submit { () -> String in
             if let match =
@@ -321,6 +325,7 @@ internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Returns the `PeerID` for the matching `Multiaddr`
     func getPeerID(byAddress address: Multiaddr, on: EventLoop? = nil) -> EventLoopFuture<PeerID> {
         eventLoop.submit { () -> PeerID in
             if let match =
@@ -335,6 +340,7 @@ internal final class BasicInMemoryPeerStore: PeerStore, @unchecked Sendable {
         }.hop(to: on ?? eventLoop)
     }
 
+    /// Returns the `PeerInfo` for the matching `Multiaddr`
     func getPeerInfo(byAddress address: Multiaddr, on: EventLoop? = nil) -> EventLoopFuture<PeerInfo> {
         eventLoop.submit { () -> PeerInfo in
             if let match =

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -42,10 +42,30 @@ extension Application {
         return true
     }
 
+    /// Resolves a `Multiaddr` into a set of 'dialable' addresses.
+    ///
+    /// - Note: We say 'dialable', instead of 'concrete', addresses because the resolved addresses may still
+    /// be `.dns` family prefrixed addresses that will still need A/AAAA name resolution, but TCP and most
+    /// Transports support top level A/AAAA name resolution at dial time. If you need a concrete IP address
+    /// you can call `resolve(Multiaddr)` on it again.
+    ///
+    /// - Parameters:
+    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    /// - Returns: A set of 'dialable' `Multiaddr`s or `nil` if none exist.
     public func resolve(_ multiaddr: Multiaddr) async throws -> [Multiaddr]? {
         try await self.resolve(multiaddr).get()
     }
 
+    /// Resolves a `Multiaddr` into a set of 'dialable' addresses.
+    ///
+    /// - Note: We say 'dialable', instead of 'concrete', addresses because the resolved addresses may still
+    /// be `.dns` family prefrixed addresses that will still need A/AAAA name resolution, but TCP and most
+    /// Transports support top level A/AAAA name resolution at dial time. If you need a concrete IP address
+    /// you can call `resolve(Multiaddr)` on it again.
+    ///
+    /// - Parameters:
+    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    /// - Returns: A set of 'dialable' `Multiaddr`s or `nil` if none exist.
     public func resolve(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
         self.logger.trace("Attempting to resolve \(multiaddr)")
         let el = self.eventLoopGroup.next()
@@ -71,15 +91,39 @@ extension Application {
                     return el.makeSucceededFuture(nil)
                 }
 
+                // TODO: Cache the resolved addresses
+
                 return el.makeSucceededFuture(Array(uniqueSet))
             }
         }
     }
 
+    /// Resolves a `Multiaddr` into a 'dialable' address that conforms to the specified `Codec` set.
+    ///
+    /// - Note: We say a 'dialable', instead of 'concrete', address because the resolved address may still
+    /// be a `.dns` family prefrixed address that will still need A/AAAA name resolution, but TCP and most
+    /// Transports support top level A/AAAA name resolution. If you need a concrete IP address you can call
+    /// `resolve(Multiaddr)` on it again.
+    ///
+    /// - Parameters:
+    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    ///   - codecs: A set of `MultiaddrProtocol` the resolved address must conform to. Ex: [.ipv4, .tcp]
+    /// - Returns: A 'dialable' `Multiaddr` that conforms to the provided Codec set or `nil` if one doesn't exist.
     public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) async throws -> Multiaddr? {
         try await self.resolve(multiaddr, for: codecs).get()
     }
 
+    /// Resolves a `Multiaddr` into a 'dialable' address that conforms to the specified `Codec` set.
+    ///
+    /// - Note: We say a 'dialable', instead of 'concrete', address because the resolved address may still
+    /// be a `.dns` family prefrixed address that will still need A/AAAA name resolution, but TCP and most
+    /// Transports support top level A/AAAA name resolution. If you need a concrete IP address you can call
+    /// `resolve(Multiaddr)` on it again.
+    ///
+    /// - Parameters:
+    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    ///   - codecs: A set of `MultiaddrProtocol` the resolved address must conform to. Ex: [.ipv4, .tcp]
+    /// - Returns: A 'dialable' `Multiaddr` that conforms to the provided Codec set or `nil` if one doesn't exist.
     public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?> {
         self.logger.trace("Attempting to resolve \(multiaddr) for \(self.list(codecs))")
         let el = self.eventLoopGroup.next()
@@ -104,6 +148,8 @@ extension Application {
                     self.logger.info("Unable to resolve \(multiaddr) for \(self.list(codecs))")
                     return el.makeSucceededFuture(nil)
                 }
+
+                // TODO: Cache the resolved address
 
                 return el.makeSucceededFuture(uniqueSet.first)
             }

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -21,8 +21,8 @@ import NIOConcurrencyHelpers
 
 public protocol AddressResolver: Sendable {
     static var key: String { get }
+    func can(resolve: Multiaddr) -> Bool
     func resolve(multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?>
-    func resolve(multiaddr: Multiaddr, for: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?>
 }
 
 extension Application {

--- a/Sources/LibP2P/Resolver/Application+Resolver.swift
+++ b/Sources/LibP2P/Resolver/Application+Resolver.swift
@@ -27,19 +27,31 @@ public protocol AddressResolver: Sendable {
 
 extension Application {
 
-    /// A list of codecs that our installed resolvers *might* be able to resolve
-    static let DNSCodecs: Set<MultiaddrProtocol> = [.dns, .dns4, .dns6, .dnsaddr]
-
     public var resolvers: Resolvers {
         .init(application: self)
     }
 
-    /// Compares the leading codec of the given `Multiaddr` against our set of `DNSCodecs`
-    private func isMultiaddrResolvable(_ ma: Multiaddr) -> Bool {
-        guard let codec = ma.addresses.first?.codec, Application.DNSCodecs.contains(codec) else {
-            return false
-        }
-        return true
+    /// Resolves a `Multiaddr` into a set of 'dialable' addresses.
+    ///
+    /// - Note: We say 'dialable', instead of 'concrete', addresses because the resolved addresses may still
+    /// be `.dns` family prefrixed addresses that will still need A/AAAA name resolution, but TCP and most
+    /// Transports support top level A/AAAA name resolution at dial time. If you need a concrete IP address
+    /// you can call `resolve(Multiaddr)` on it again.
+    ///
+    /// Successful resolutions are cached for `app.resolvers.cacheTTL`, and concurrent requests for the
+    /// same `Multiaddr` are coalesced onto a single in-flight resolution.
+    ///
+    /// - Parameters:
+    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    ///   - skipCache: Forces a fresh resolution, ignoring any cached result for this address
+    ///   - timeout: How long any single resolver is given to answer before we move on without it
+    /// - Returns: A set of 'dialable' `Multiaddr`s or `nil` if none exist.
+    public func resolve(
+        _ multiaddr: Multiaddr,
+        skipCache: Bool = false,
+        timeout: TimeAmount = .seconds(3)
+    ) async throws -> [Multiaddr]? {
+        try await self.resolve(multiaddr, skipCache: skipCache, timeout: timeout).get()
     }
 
     /// Resolves a `Multiaddr` into a set of 'dialable' addresses.
@@ -49,52 +61,63 @@ extension Application {
     /// Transports support top level A/AAAA name resolution at dial time. If you need a concrete IP address
     /// you can call `resolve(Multiaddr)` on it again.
     ///
-    /// - Parameters:
-    ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
-    /// - Returns: A set of 'dialable' `Multiaddr`s or `nil` if none exist.
-    public func resolve(_ multiaddr: Multiaddr) async throws -> [Multiaddr]? {
-        try await self.resolve(multiaddr).get()
-    }
-
-    /// Resolves a `Multiaddr` into a set of 'dialable' addresses.
-    ///
-    /// - Note: We say 'dialable', instead of 'concrete', addresses because the resolved addresses may still
-    /// be `.dns` family prefrixed addresses that will still need A/AAAA name resolution, but TCP and most
-    /// Transports support top level A/AAAA name resolution at dial time. If you need a concrete IP address
-    /// you can call `resolve(Multiaddr)` on it again.
+    /// Successful resolutions are cached for `app.resolvers.cacheTTL`, and concurrent requests for the
+    /// same `Multiaddr` are coalesced onto a single in-flight resolution.
     ///
     /// - Parameters:
     ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
+    ///   - skipCache: Forces a fresh resolution, ignoring any cached result for this address
+    ///   - timeout: How long any single resolver is given to answer before we move on without it
     /// - Returns: A set of 'dialable' `Multiaddr`s or `nil` if none exist.
-    public func resolve(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
+    public func resolve(
+        _ multiaddr: Multiaddr,
+        skipCache: Bool = false,
+        timeout: TimeAmount = .seconds(3)
+    ) -> EventLoopFuture<[Multiaddr]?> {
         self.logger.trace("Attempting to resolve \(multiaddr)")
         let el = self.eventLoopGroup.next()
-        guard isMultiaddrResolvable(multiaddr) else {
+        guard self.resolvers.can(resolve: multiaddr) else {
             self.logger.info("Unable to resolve \(multiaddr)")
             return el.makeSucceededFuture(nil)
         }
 
-        return self.isCached(multiaddr).flatMap { cachedAddresses in
-            guard cachedAddresses.isEmpty else { return el.makeSucceededFuture(cachedAddresses) }
+        // Ask the resolution cache to either serve this address, hand us an in-flight resolution to
+        // wait on, or grant us the right to resolve it ourselves.
+        switch self.resolvers.cacheResult(multiaddr, skipCache: skipCache, on: el) {
+        case .hit(let addresses):
+            self.logger.trace("Resolved \(multiaddr) from cache")
+            return el.makeSucceededFuture(addresses)
 
-            return self.resolvers.allResolvers.map {
-                $0.resolve(multiaddr: multiaddr)
-            }.flatten(on: el).flatMap { allAddress in
-                let uniqueSet = Set(
-                    allAddress.reduce(into: [Multiaddr]()) { partialResult, addys in
-                        partialResult.append(contentsOf: addys ?? [])
-                    }
-                )
+        case .joined(let inFlight):
+            self.logger.trace("Joining an in-flight resolution of \(multiaddr)")
+            return inFlight.hop(to: el)
 
-                guard !uniqueSet.isEmpty else {
+        case .claimed(let promise):
+            self.consolidateResolvedAddresses(multiaddr, timeout: timeout, on: el).flatMap {
+                resolved -> EventLoopFuture<[Multiaddr]?> in
+                guard !resolved.isEmpty else {
                     self.logger.info("Unable to resolve \(multiaddr)")
                     return el.makeSucceededFuture(nil)
                 }
 
-                // TODO: Cache the resolved addresses
-
-                return el.makeSucceededFuture(Array(uniqueSet))
+                // Publish the addresses to our peerstore so the rest of the stack can dial them
+                return self.publishToPeerStore(resolvedAddresses: resolved, for: multiaddr, on: el)
+                    .flatMapAlways { result -> EventLoopFuture<[Multiaddr]?> in
+                        if case .failure(let error) = result {
+                            self.logger.warning(
+                                "Failed to publish the resolved addresses for \(multiaddr) to our peerstore: \(error)"
+                            )
+                        }
+                        return el.makeSucceededFuture(resolved)
+                    }
+            }.whenComplete { result in
+                // Settle the cache entry before the promise, so that anyone woken by the promise sees
+                // the finished entry rather than the in-flight one it replaces.
+                self.resolvers.settle(multiaddr, with: result)
+                promise.completeWith(result)
             }
+
+            return promise.futureResult
         }
     }
 
@@ -105,12 +128,22 @@ extension Application {
     /// Transports support top level A/AAAA name resolution. If you need a concrete IP address you can call
     /// `resolve(Multiaddr)` on it again.
     ///
+    /// Successful resolutions are cached for `app.resolvers.cacheTTL`, and concurrent requests for the
+    /// same `Multiaddr` are coalesced onto a single in-flight resolution.
+    ///
     /// - Parameters:
     ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
     ///   - codecs: A set of `MultiaddrProtocol` the resolved address must conform to. Ex: [.ipv4, .tcp]
+    ///   - skipCache: Forces a fresh resolution, ignoring any cached result for this address
+    ///   - timeout: How long any single resolver is given to answer before we move on without it
     /// - Returns: A 'dialable' `Multiaddr` that conforms to the provided Codec set or `nil` if one doesn't exist.
-    public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) async throws -> Multiaddr? {
-        try await self.resolve(multiaddr, for: codecs).get()
+    public func resolve(
+        _ multiaddr: Multiaddr,
+        for codecs: Set<MultiaddrProtocol>,
+        skipCache: Bool = false,
+        timeout: TimeAmount = .seconds(3)
+    ) async throws -> Multiaddr? {
+        try await self.resolve(multiaddr, for: codecs, skipCache: skipCache, timeout: timeout).get()
     }
 
     /// Resolves a `Multiaddr` into a 'dialable' address that conforms to the specified `Codec` set.
@@ -120,81 +153,29 @@ extension Application {
     /// Transports support top level A/AAAA name resolution. If you need a concrete IP address you can call
     /// `resolve(Multiaddr)` on it again.
     ///
+    /// Successful resolutions are cached for `app.resolvers.cacheTTL`, and concurrent requests for the
+    /// same `Multiaddr` are coalesced onto a single in-flight resolution.
+    ///
     /// - Parameters:
     ///   - multiaddr: The `Multiaddr` to be resolved into a 'dialable' `Multiaddr`
     ///   - codecs: A set of `MultiaddrProtocol` the resolved address must conform to. Ex: [.ipv4, .tcp]
+    ///   - skipCache: Forces a fresh resolution, ignoring any cached result for this address
+    ///   - timeout: How long any single resolver is given to answer before we move on without it
     /// - Returns: A 'dialable' `Multiaddr` that conforms to the provided Codec set or `nil` if one doesn't exist.
-    public func resolve(_ multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol>) -> EventLoopFuture<Multiaddr?> {
+    public func resolve(
+        _ multiaddr: Multiaddr,
+        for codecs: Set<MultiaddrProtocol>,
+        skipCache: Bool = false,
+        timeout: TimeAmount = .seconds(3)
+    ) -> EventLoopFuture<Multiaddr?> {
         self.logger.trace("Attempting to resolve \(multiaddr) for \(self.list(codecs))")
-        let el = self.eventLoopGroup.next()
-        guard isMultiaddrResolvable(multiaddr) else {
-            self.logger.info("Unable to resolve \(multiaddr) for \(self.list(codecs))")
-            return el.makeSucceededFuture(nil)
-        }
 
-        return self.isCached(multiaddr).flatMap { cachedAddresses in
-            guard cachedAddresses.isEmpty else {
-                return el.makeSucceededFuture(
-                    cachedAddresses.first(where: { Set($0.protocols()).isSuperset(of: codecs) })
-                )
+        return self.resolve(multiaddr, skipCache: skipCache, timeout: timeout).map { mas in
+            guard let addresses = mas, !addresses.isEmpty else {
+                return nil
             }
-
-            return self.resolvers.allResolvers.map {
-                $0.resolve(multiaddr: multiaddr, for: codecs)
-            }.flatten(on: el).flatMap { allAddress in
-                let uniqueSet = Set(allAddress.compactMap { $0 })
-
-                guard !uniqueSet.isEmpty else {
-                    self.logger.info("Unable to resolve \(multiaddr) for \(self.list(codecs))")
-                    return el.makeSucceededFuture(nil)
-                }
-
-                // TODO: Cache the resolved address
-
-                return el.makeSucceededFuture(uniqueSet.first)
-            }
-        }
-    }
-
-    /// Pretty prints a MultiaddrProtocol set
-    private func list(_ codecs: Set<MultiaddrProtocol>) -> String {
-        "[\(codecs.map({ $0.name }).joined(separator: ","))]"
-    }
-
-    /// Checks our PeerStore for a cached address to dial for the given Multiaddr
-    ///
-    /// - Note: There is no active TTL mechanism here
-    private func isCached(_ multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]> {
-        let el = self.eventLoopGroup.next()
-
-        // Search by PeerID if possible
-        // Note: We end up saving the resolved address in our peerstore, so usually a peerID lookup is the only way to find a hit
-        if let pid = try? multiaddr.getPeerID() {
-            return self.peers.getAddresses(forPeer: pid, on: el).flatMapAlways {
-                result -> EventLoopFuture<[Multiaddr]> in
-                // TODO: Should we check the last handshake time as a TTL
-                switch result {
-                case .success(let addresses):
-                    return el.makeSucceededFuture(
-                        addresses.filter { $0 != multiaddr }
-                    )
-                case .failure:
-                    return el.makeSucceededFuture([])
-                }
-            }
-        } else {  // Search by multiaddr
-            return self.peers.getPeerInfo(byAddress: multiaddr, on: el).flatMapAlways {
-                result -> EventLoopFuture<[Multiaddr]> in
-                // TODO: Should we check the last handshake time as a TTL
-                switch result {
-                case .success(let peerInfo):
-                    return el.makeSucceededFuture(
-                        peerInfo.addresses.filter { $0 != multiaddr }
-                    )
-                case .failure:
-                    return el.makeSucceededFuture([])
-                }
-            }
+            let match = addresses.first(where: { Set($0.protocols()).isSuperset(of: codecs) })
+            return match
         }
     }
 
@@ -207,10 +188,36 @@ extension Application {
             }
         }
 
+        /// A single entry in the resolution cache.
+        enum CacheEntry {
+            /// A completed resolution, good until `expiresAt`.
+            case resolved(addresses: [Multiaddr], expiresAt: Date)
+            /// A resolution that's currently running. Concurrent callers wait on this future rather
+            /// than kicking off a second, redundant resolution of the same address.
+            case inFlight(EventLoopFuture<[Multiaddr]?>)
+        }
+
+        /// The outcome of asking the resolution cache to serve a `Multiaddr`.
+        enum CacheResult {
+            /// A fresh cached result.
+            case hit([Multiaddr])
+            /// Someone else is already resolving this address; wait on their result.
+            case joined(EventLoopFuture<[Multiaddr]?>)
+            /// The caller now owns this resolution and must `settle` it when done.
+            case claimed(EventLoopPromise<[Multiaddr]?>)
+        }
+
+        /// Upper bound on cached resolutions, so a long lived host can't grow this map without limit.
+        private static let maxCacheEntries = 256
+
         final class Storage: Sendable {
             let resolvers: NIOLockedValueBox<[String: AddressResolver]>
+            let cache: NIOLockedValueBox<[Multiaddr: CacheEntry]>
+            let ttl: NIOLockedValueBox<TimeAmount>
             init() {
                 self.resolvers = .init([:])
+                self.cache = .init([:])
+                self.ttl = .init(.minutes(3))
             }
         }
 
@@ -233,8 +240,133 @@ extension Application {
 
         let application: Application
 
+        /// Asks the installed / registered resolvers if the specified `Multiaddr` is resolvable
+        ///
+        /// - Note: Use this as a cheap / synchronous option before actually attempting to resolve the address with `app.resolve(Multiaddr)`
+        ///
+        /// - Parameter ma: The `Multiaddr` that we're interested in resolving
+        /// - Returns: `true` if at least one of the resolvers is capable of resolving the address, `false` otherwise
+        public func can(resolve ma: Multiaddr) -> Bool {
+            allResolvers.contains(where: { $0.can(resolve: ma) })
+        }
+
+        /// How long a resolved set of addresses stays valid in the resolution cache.
+        ///
+        /// Defaults to 3 minutes. Changing this only affects resolutions completed from here on;
+        /// entries already in the cache keep the expiry they were stored with.
+        public var cacheTTL: TimeAmount {
+            get { self.storage.ttl.withLockedValue { $0 } }
+            nonmutating set { self.storage.ttl.withLockedValue { $0 = newValue } }
+        }
+
+        /// Drops every completed entry from the resolution cache.
+        ///
+        /// In-flight resolutions are left alone; callers are already waiting on them, and their results
+        /// will repopulate the cache as they settle.
+        public func clearCache() {
+            self.storage.cache.withLockedValue { cache in
+                cache = cache.filter { _, entry in
+                    if case .inFlight = entry { return true }
+                    return false
+                }
+            }
+        }
+
+        /// Every installed resolver, in a stable order.
+        ///
+        /// The registry is a dictionary, whose iteration order varies from run to run, so we order by key
+        /// here — otherwise the addresses an aggregated resolution reports would be ordered arbitrarily
+        /// whenever more than one resolver can serve an address.
         fileprivate var allResolvers: [AddressResolver] {
-            self.storage.resolvers.withLockedValue { $0.values.map { $0 } }
+            self.storage.resolvers.withLockedValue { resolvers in
+                resolvers.sorted { $0.key < $1.key }.map { $0.value }
+            }
+        }
+
+        /// Every installed resolver that can resolve the `Multiaddr`, in a stable order.
+        ///
+        /// The registry is a dictionary, whose iteration order varies from run to run, so we order by key
+        /// here — otherwise the addresses an aggregated resolution reports would be ordered arbitrarily
+        /// whenever more than one resolver can serve an address.
+        fileprivate func allResolvers(for ma: Multiaddr) -> [AddressResolver] {
+            self.allResolvers.filter { $0.can(resolve: ma) }
+        }
+
+        /// Serves `ma` from the resolution cache, joins an in-flight resolution of it, or claims the
+        /// right to resolve it.
+        ///
+        /// The lookup and the claim happen under a single lock acquisition, so two callers racing on the
+        /// same address can't both decide to resolve it.
+        ///
+        /// - Important: A `.claimed` promise MUST be paired with a call to `settle(_:with:)`, otherwise
+        /// the in-flight entry it installed will strand every later caller for this address.
+        fileprivate func cacheResult(_ ma: Multiaddr, skipCache: Bool, on el: EventLoop) -> CacheResult {
+            self.storage.cache.withLockedValue { cache in
+                if !skipCache, let entry = cache[ma] {
+                    switch entry {
+                    case .resolved(let addresses, let expiresAt):
+                        if Date() < expiresAt { return .hit(addresses) }
+                    case .inFlight(let future):
+                        return .joined(future)
+                    }
+                }
+
+                // Either nothing was cached, the entry expired, or the caller demanded a fresh
+                // resolution. Install ourselves as the in-flight resolution and take ownership.
+                let promise = el.makePromise(of: [Multiaddr]?.self)
+                cache[ma] = .inFlight(promise.futureResult)
+                // Take this opportunity to prune the cache
+                Self.prune(&cache)
+                return .claimed(promise)
+            }
+        }
+
+        /// Publishes the outcome of a resolution we claimed, replacing the in-flight entry it installed.
+        ///
+        /// Only non-empty successes are cached. A failure or an empty result drops the entry entirely so
+        /// the next caller retries, rather than inheriting a negative result for the full TTL.
+        ///
+        /// - Note: A concurrent `skipCache` resolution can replace our in-flight entry before we settle,
+        /// in which case the later of the two to settle wins. Both are fresh results, so either is fine.
+        fileprivate func settle(_ ma: Multiaddr, with result: Result<[Multiaddr]?, Error>) {
+            let ttl = self.cacheTTL
+            self.storage.cache.withLockedValue { cache in
+                guard case .success(let resolved) = result, let addresses = resolved, !addresses.isEmpty
+                else {
+                    cache[ma] = nil
+                    return
+                }
+                cache[ma] = .resolved(
+                    addresses: addresses,
+                    expiresAt: Date().addingTimeInterval(ttl.asSeconds)
+                )
+            }
+        }
+
+        /// Keeps the cache bounded. Expired entries go first, then the soonest to expire.
+        ///
+        /// In-flight entries are never evicted, since callers are waiting on them and dropping one
+        /// would let a duplicate resolution start behind it.
+        private static func prune(_ cache: inout [Multiaddr: CacheEntry]) {
+            guard cache.count > maxCacheEntries else { return }
+
+            // Drop any expired resolved entries
+            let now = Date()
+            cache = cache.filter { _, entry in
+                guard case .resolved(_, let expiresAt) = entry else { return true }
+                return now < expiresAt
+            }
+
+            guard cache.count > maxCacheEntries else { return }
+            // If we're still over our limit, drop the oldest resolved entries
+            let evictable = cache.compactMap { key, entry -> (Multiaddr, Date)? in
+                guard case .resolved(_, let expiresAt) = entry else { return nil }
+                return (key, expiresAt)
+            }.sorted { $0.1 < $1.1 }
+
+            for (key, _) in evictable.prefix(cache.count - maxCacheEntries) {
+                cache[key] = nil
+            }
         }
 
         var storage: Storage {
@@ -250,5 +382,95 @@ extension Application {
             }
             return storage
         }
+    }
+
+    // - MARK: Private helper methods
+
+    /// For each resolver that can resolve the address, ask it to resolve it, aggregating the results.
+    ///
+    /// Each resolver is bounded by `timeout` and individually insulated from failure, so one slow or
+    /// broken resolver can't take the whole resolution down with it.
+    ///
+    /// - Note: The order in which each resolver reports its addresses is preserved, and duplicates are
+    /// dropped in favor of their first occurrence. A resolver's ordering carries intent, a peer's `dnsaddr`
+    /// records list its preferred endpoints first, and `resolve(_:for:)` hands back the first address
+    /// matching the requested codecs, so aggregation should respect ordering.
+    private func consolidateResolvedAddresses(
+        _ multiaddr: Multiaddr,
+        timeout: TimeAmount,
+        on el: EventLoop
+    ) -> EventLoopFuture<[Multiaddr]> {
+        self.resolvers.allResolvers(for: multiaddr).map { resolver in
+            self.resolve(multiaddr, using: resolver, timeout: timeout, on: el)
+        }.flatten(on: el).map { allAddresses in
+            // `flatten` preserves the order the resolvers were consulted in, so we only need to flatten
+            // and de-duplicate.
+            var seen: Set<Multiaddr> = []
+            return allAddresses.compactMap { $0 }.flatMap { $0 }.filter { seen.insert($0).inserted }
+        }
+    }
+
+    /// Asks a single `AddressResolver` to resolve the given `Multiaddr`, bounded by `timeout`.
+    ///
+    /// Neither a failure nor a timeout is propagated to the caller; both resolve to `nil` so that one
+    /// misbehaving resolver only costs us its own contribution, never the whole resolution.
+    ///
+    /// - Returns: A future that always succeeds, within `timeout`, with the resolver's addresses or `nil`.
+    private func resolve(
+        _ multiaddr: Multiaddr,
+        using resolver: AddressResolver,
+        timeout: TimeAmount,
+        on el: EventLoop
+    ) -> EventLoopFuture<[Multiaddr]?> {
+        let promise = el.makePromise(of: [Multiaddr]?.self)
+
+        // Start our timeout task
+        let timeoutTask = el.scheduleTask(in: timeout) {
+            self.logger.warning(
+                "Resolver[\(type(of: resolver).key)] timed out after \(Int(timeout.asMilliseconds))ms resolving \(multiaddr)"
+            )
+            promise.succeed(nil)
+        }
+
+        // Cancel the timeoutTask as soon as we resolve.
+        promise.futureResult.whenComplete { _ in timeoutTask.cancel() }
+
+        // Kick off the resolve and succeed the results
+        resolver.resolve(multiaddr: multiaddr).hop(to: el).whenComplete { result in
+            switch result {
+            case .success(let addresses):
+                promise.succeed(addresses)
+            case .failure(let error):
+                self.logger.warning(
+                    "Resolver[\(type(of: resolver).key)] failed to resolve \(multiaddr): \(error)"
+                )
+                promise.succeed(nil)
+            }
+        }
+
+        return promise.futureResult
+    }
+
+    /// Pretty prints a MultiaddrProtocol set
+    private func list(_ codecs: Set<MultiaddrProtocol>) -> String {
+        "[\(codecs.map({ $0.name }).joined(separator: ","))]"
+    }
+
+    /// Records the resolved addresses in our peerstore, so that the rest of the stack can dial them.
+    ///
+    /// - Note: This is a publication, not a cache write. The resolution cache is authoritative for
+    /// resolution results; the peerstore is where the rest of the stack looks for a peer's addresses.
+    ///
+    /// - Note: If the original `Multiaddr` we resolved wasn't encapsulated with a `PeerID` then we have
+    /// nothing to file the addresses under, so we don't store them.
+    private func publishToPeerStore(
+        resolvedAddresses: [Multiaddr],
+        for ma: Multiaddr,
+        on el: EventLoop
+    ) -> EventLoopFuture<Void> {
+        guard let pid = try? ma.getPeerID() else {
+            return el.makeSucceededVoidFuture()
+        }
+        return self.peers.add(addresses: resolvedAddresses, toPeer: pid, on: el)
     }
 }

--- a/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
+++ b/Sources/LibP2P/Utilities/Multiaddr+Transport.swift
@@ -28,10 +28,6 @@ extension Multiaddr {
 
         /// If our multiaddr is using the `dnsaddr` protocol, attempt to resolve it for a tcp ipv4 address
         if self.addresses.first?.codec == .dnsaddr {
-            //            #if canImport(LibP2PDNSAddr)
-            //            return self.resolve(for: [Codecs.ip4, Codecs.tcp])?.tcpAddress
-            //            #endif
-            print("ERROR: Can't resolve DNS Address without DNSADDR dependency")
             return nil
         }
 
@@ -82,10 +78,6 @@ extension Multiaddr {
 
         /// If our multiaddr is using the `dnsaddr` protocol, attempt to resolve it for a tcp ipv4 address
         if self.addresses.first?.codec == .dnsaddr {
-            //            #if canImport(LibP2PDNSAddr)
-            //            return self.resolve(for: [.ip4, .udp])?.udpAddress
-            //            #endif
-            print("Error: Can't resolve DNSAddr without LibP2PDNSAddr module")
             return nil
         }
 


### PR DESCRIPTION
### What?
This PR updates our Applications' Resolvers interface.

### Changes:
- `app.resolve(...)` now supports
    - A TTL Cache
    - Concurrent call coalescing (for the same `Multiaddr`)
    - Resolution timeouts
    - Address order preserving resolutions
- Callers have the ability to force a new resolve with `skipCache: true` and adjust the timeout with `timeout:`. 
- The cache TTL is configurable at `app.resolvers.cacheTTL` and although the cache prunes itself, you can call `app.resolvers.clearCache` to clear the cache of all resolved entries.

### Resolution Flow
For every call to `app.resolve(...)`, we first consult our cache and return a hit if there is one, otherwise we check for inflight resolutions for the same `Multiaddr` and return the future result if there is one outstanding, otherwise we ask each resolver that can resolve the `Multiaddr` to try and do so (within the given time limit), we consolidate the successes, cache them and return them in order. 

> [!IMPORTANT]
> Technically this contains a breaking change because the public `AddressResolver` protocol has changed, but I'm skipping the minor version bump and just updating our only conformer, `LibP2PDNSAddr`, directly. Apologies if this causes anyone issues.